### PR TITLE
#9 show setup page as long as no password is configured

### DIFF
--- a/php/src/Data/ConfigurationManager.php
+++ b/php/src/Data/ConfigurationManager.php
@@ -22,9 +22,12 @@ class ConfigurationManager
         return $this->GetConfig()['username'];
     }
 
-    public function GetPassword() : string {
-        return $this->GetConfig()['password'];
-    }
+    public function GetPassword() : ?string {
+        if(array_key_exists('password', $this->GetConfig())){
+            return $this->GetConfig()['password'];
+        }
+        else return null;
+     }
 
     public function GetToken() : string {
         return $this->GetConfig()['AIO_TOKEN'];

--- a/php/src/Data/Setup.php
+++ b/php/src/Data/Setup.php
@@ -27,6 +27,6 @@ class Setup
     }
 
     public function CanBeInstalled() : bool {
-        return !file_exists(DataConst::GetConfigFile());
+        return is_null($this->configurationManager->GetPassword());
     }
 }


### PR DESCRIPTION
This should fix the problems users have during inital setup. This solution shows the setup page as long as the configuration does not yet contain a password.