### PR TITLE
fix docker permission issues

### DIFF
--- a/Containers/mastercontainer/Dockerfile
+++ b/Containers/mastercontainer/Dockerfile
@@ -75,14 +75,8 @@ RUN chmod +x /usr/bin/start.sh; \
     chmod +r /Caddyfile; \
     chmod +x /cron.sh
 
-# add docker group
-RUN groupadd -g 998 docker && \
-    usermod -aG docker www-data
-
 # Give root a random password
 RUN echo "root:$(openssl rand -base64 12)" | chpasswd
-
-USER www-data
 
 ENTRYPOINT ["start.sh"]
 CMD ["/usr/bin/supervisord", "-c", "/supervisord.conf"]

--- a/Containers/mastercontainer/Dockerfile
+++ b/Containers/mastercontainer/Dockerfile
@@ -2,16 +2,14 @@
 FROM php:8.0-apache-bullseye
 
 EXPOSE 80
-# EXPOSE 8080
+EXPOSE 8080
 EXPOSE 8443
 
-RUN mkdir -p /mnt/docker-aio-config/; \
-    chown www-data:www-data /mnt/docker-aio-config;
+RUN mkdir -p /mnt/docker-aio-config/;
 
 VOLUME /mnt/docker-aio-config/
 
-RUN mkdir -p /var/www/docker-aio; \
-    chown -R www-data:www-data /var/www;
+RUN mkdir -p /var/www/docker-aio;
 
 WORKDIR /var/www/docker-aio
 
@@ -25,18 +23,16 @@ RUN apt-get update; \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl "https://caddyserver.com/api/download?os=linux&arch=amd64" -o "/usr/bin/caddy" \
-    && chmod 0755 /usr/bin/caddy \
+    && chmod +x /usr/bin/caddy \
     && /usr/bin/caddy version
 
 RUN cd /var/www/docker-aio; \
     git clone https://github.com/nextcloud/all-in-one.git .; \
-    chown -R www-data:www-data ./; \
     chmod 770 -R ./
 
 RUN mkdir -p /etc/apache2/certs && \
     cd /etc/apache2/certs && \
-    openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/C=DE/ST=BE/L=Local/O=Dev/CN=nextcloud.local" -keyout ./ssl.key -out ./ssl.crt; \
-    chown www-data:www-data -R /etc/apache2/certs;
+    openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/C=DE/ST=BE/L=Local/O=Dev/CN=nextcloud.local" -keyout ./ssl.key -out ./ssl.crt;
 
 COPY mastercontainer.conf /etc/apache2/sites-available/
 
@@ -60,23 +56,20 @@ RUN a2dissite 000-default && \
     service apache2 restart
 
 RUN mkdir /var/log/supervisord; \
-    mkdir /var/run/supervisord; \
-    chown www-data:www-data /var/run/supervisord; \
-    chown www-data:www-data /var/log/supervisord;
+    mkdir /var/run/supervisord;
 
-RUN mkdir -p /usr/src/php/ext/apcu && curl -fsSL https://pecl.php.net/get/apcu | tar xvz -C "/usr/src/php/ext/apcu" --strip 1 && docker-php-ext-install apcu
+RUN mkdir -p /usr/src/php/ext/apcu && \
+    curl -fsSL https://pecl.php.net/get/apcu | tar xvz -C "/usr/src/php/ext/apcu" --strip 1 && \
+    docker-php-ext-install apcu
 
 COPY Caddyfile /
 COPY start.sh /usr/bin/
 COPY cron.sh /
 COPY supervisord.conf /
 RUN chmod +x /usr/bin/start.sh; \
-    chmod +r /supervisord.conf; \
-    chmod +r /Caddyfile; \
     chmod +x /cron.sh
 
-# Give root a random password
-RUN echo "root:$(openssl rand -base64 12)" | chpasswd
+USER root
 
 ENTRYPOINT ["start.sh"]
 CMD ["/usr/bin/supervisord", "-c", "/supervisord.conf"]

--- a/Containers/mastercontainer/start.sh
+++ b/Containers/mastercontainer/start.sh
@@ -10,9 +10,15 @@ print_green() {
 if ! [ -a "/var/run/docker.sock" ]; then
     echo "Docker socket is not available. Cannot continue."
     exit 1
-elif ! test -r /var/run/docker.sock; then
-    echo "Docker socket is not readable by the www-data user. Cannot continue."
-    exit 1
+elif ! su www-data -s /bin/bash -c "test -r /var/run/docker.sock"; then
+    echo "Trying to fix docker.sock permissions..."
+    GROUP=$(stat -c '%g' /var/run/docker.sock)
+    groupadd -g "$GROUP" docker && \
+    usermod -aG docker www-data
+    if ! su www-data -s /bin/bash -c "test -r /var/run/docker.sock"; then
+        echo "Docker socket is not readable by the www-data user. Cannot continue."
+        exit 1
+    fi
 fi
 
 # Check if volume is writeable
@@ -58,7 +64,7 @@ if [ -f ./ssl.crt ] && [ -f ./ssl.key ]; then
     cp "$GENERATED_CERTS/ssl.crt" ./
     cp "$GENERATED_CERTS/ssl.key" ./
 fi
-
+chown -R www-data /mnt/docker-aio-config /etc/apache2/certs/ssl.*
 print_green "Initial startup of Nextcloud All In One complete!
 You should be able to open the Nextcloud AIO Interface now on port 8080 of this server!
 E.g. https://internal.ip.of.this.server:8080

--- a/Containers/mastercontainer/supervisord.conf
+++ b/Containers/mastercontainer/supervisord.conf
@@ -5,26 +5,22 @@ logfile=/var/log/supervisord/supervisord.log
 pidfile=/var/run/supervisord/supervisord.pid
 childlogdir=/var/log/supervisord/
 logfile_maxbytes=50MB                           
-logfile_backups=10                              
+logfile_backups=10                 
 loglevel=error
+user=www-data
+environment=HOME="/var/www/docker-aio",USER="www-data"
 
 [program:apache]
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
 command=apache2-foreground
+user=www-data
+environment=HOME="/var/www/docker-aio",USER="www-data"
 
 [program:caddy]
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
 command=/usr/bin/caddy run -config /Caddyfile
+user=www-data
+environment=HOME="/var/www/docker-aio",USER="www-data"
 
 [program:cron]
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
 command=/cron.sh
+user=www-data
+environment=HOME="/var/www/docker-aio",USER="www-data"

--- a/Containers/mastercontainer/supervisord.conf
+++ b/Containers/mastercontainer/supervisord.conf
@@ -7,20 +7,24 @@ childlogdir=/var/log/supervisord/
 logfile_maxbytes=50MB                           
 logfile_backups=10                 
 loglevel=error
-user=www-data
-environment=HOME="/var/www/docker-aio",USER="www-data"
 
 [program:apache]
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 command=apache2-foreground
-user=www-data
-environment=HOME="/var/www/docker-aio",USER="www-data"
 
 [program:caddy]
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 command=/usr/bin/caddy run -config /Caddyfile
-user=www-data
-environment=HOME="/var/www/docker-aio",USER="www-data"
 
 [program:cron]
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 command=/cron.sh
-user=www-data
-environment=HOME="/var/www/docker-aio",USER="www-data"

--- a/Containers/watchtower/Dockerfile
+++ b/Containers/watchtower/Dockerfile
@@ -8,7 +8,6 @@ RUN set -ex; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
         ca-certificates \
-        openssl \
     ; \
     rm -rf /var/lib/apt/lists/*
 
@@ -17,12 +16,5 @@ COPY --from=watchtower /watchtower /
 COPY start.sh /
 RUN chmod +x /start.sh
 
-# Give root a random password
-RUN echo "root:$(openssl rand -base64 12)" | chpasswd
-
-# add docker group
-RUN groupadd -g 998 docker && \
-    usermod -aG docker nobody
-
-USER nobody
+USER root
 ENTRYPOINT ["/start.sh"]

--- a/Containers/watchtower/start.sh
+++ b/Containers/watchtower/start.sh
@@ -4,15 +4,22 @@
 if ! [ -a "/var/run/docker.sock" ]; then
     echo "Docker socket is not available. Cannot continue."
     exit 1
-elif ! [ -r "/var/run/docker.sock" ]; then
-    echo "Docker socket is not readable by the nobody user. Cannot continue."
-    exit 1
+elif ! test -r /var/run/docker.sock; then
+    echo "Trying to fix docker.sock permissions internally..."
+    GROUP="$(stat -c '%g' /var/run/docker.sock)"
+    groupadd -g "$GROUP" docker && \
+    usermod -aG docker root
+    if ! test -r /var/run/docker.sock; then
+        echo "Docker socket is not readable by the root user. Cannot continue."
+        exit 1
+    fi
 fi
 
 if [ -n "$CONTAINER_TO_UPDATE" ]; then
     exec /watchtower --cleanup --run-once "$CONTAINER_TO_UPDATE"
 else
     echo "'CONTAINER_TO_UPDATE' is not set. Cannot update anything."
+    exit 1
 fi
 
 


### PR DESCRIPTION
This should fix #10 
The start.sh script of the mastercontainer now runs with root privileges so we can manage group permissions during startup. 

I adjusted the supervisor.conf of the mastercontainer so that all other processes still run as www-data, but had some issues with log file permissions, thats why I removed some logging options from the supervisor.conf. (Do we need them?)