### PR TITLE
Remove trailing whitespace from initial nextcloud password

### DIFF
--- a/php/templates/containers.twig
+++ b/php/templates/containers.twig
@@ -67,8 +67,8 @@
 
                 {% if isAnyRunning == true %}
                     {% if isApacheStarting != true %}
-                        Initial Nextcloud username: admin <br />
-                        Initial Nextcloud password: {{ nextcloud_password }} <br /><br/>
+                        Initial Nextcloud username: admin<br />
+                        Initial Nextcloud password: {{ nextcloud_password }}<br /><br/>
                         <a href="https://{{ domain }}" class="button" target="_blank" rel="noopener">Open your Nextcloud ↗</a><br/>
                     {% else %}
                         Containers are currently starting.<br /><br />


### PR DESCRIPTION
Copy-pasting the initial nextcloud password did lead to an invalid password because of trailing whitespace in the template