### PR TITLE
Build docker images for multiple architectures

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -2,6 +2,7 @@ name: Build docker images
 
 on:
   push:
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -1,0 +1,60 @@
+name: Build docker images
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ 
+          {arch: 'linux/amd64',  tag: 'develop' },
+          {arch: 'linux/arm64', tag: 'develop-arm64' } ]
+        container: [
+          {name: 'aio-apache', context: './Containers/apache'},
+          {name: 'aio-borgbackup', context: './Containers/borgbackup'},
+          {name: 'aio-collabora', context: './Containers/collabora'},
+          {name: 'aio-domaincheck', context: './Containers/domaincheck'},
+          {name: 'all-in-one', context: './Containers/mastercontainer'},
+          {name: 'aio-nextcloud', context: './Containers/nextcloud'},
+          {name: 'aio-postgresql', context: './Containers/postgresql'},
+          {name: 'aio-redis', context: './Containers/redis'},
+          {name: 'aio-talk', context: './Containers/talk'},
+          {name: 'aio-watchtower', context: './Containers/watchtower'}]
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Docker metadata
+        id: metadata
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.container.name }}
+          tags: |
+            ${{ matrix.platform.tag }}
+
+      - name: Build docker image and push to dockerhub
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ matrix.container.context }}
+          platforms: ${{matrix.platform.arch}}
+          no-cache: true
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}

--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -47,7 +47,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.container.name }}
+            nextcloud/${{ matrix.container.name }}
           tags: |
             ${{ matrix.platform.tag }}
 

--- a/develop.md
+++ b/develop.md
@@ -16,6 +16,7 @@ It will now also select the developer channel for all other containers automatic
 
 ## How to promote builds from develop to latest
 
+<!---
 You can use the Docker CLI to promote builds from develop to latest. Make sure to adjust:
 
 - $name
@@ -28,13 +29,25 @@ docker pull nextcloud/$AIO_NAME@sha256:$AIO_DIGEST
 docker tag nextcloud/$AIO_NAME@sha256:$AIO_DIGEST nextcloud/$AIO_NAME\:latest
 docker push nextcloud/$AIO_NAME\:latest
 ```
+--->
 
 To automatically promoted the latest develop version you can use the following script:
 
 **WARNING:** Make sure to verify that the latest develop tag is what you really want to deploy since someone could have pushed to main and created a new container in between.
 ```shell
+# x64
 export AIO_NAME=$name
 docker pull nextcloud/$AIO_NAME\:develop
 docker tag nextcloud/$AIO_NAME\:develop nextcloud/$AIO_NAME\:latest
 docker push nextcloud/$AIO_NAME\:latest
 ```
+
+**ATTENTION**: don't run the script below since the arm64 containers currently don't work!
+```shell
+# arm64 
+export AIO_NAME=$name
+docker pull nextcloud/$AIO_NAME\:develop-arm64
+docker tag nextcloud/$AIO_NAME\:develop-arm64 nextcloud/$AIO_NAME\:latest-arm64
+docker push nextcloud/$AIO_NAME\:latest-arm64
+```
+Later when the arm64 containers work, we can simply publish to latest and latest-arm64 in a rush by providing the name one time at the top of the script.

--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -47,12 +47,7 @@ class DockerActionManager
     }
 
     private function BuildImageName(Container $container) : string {
-        $channel = $this->GetCurrentChannel();
-        if ($channel === 'develop') {
-            return $container->GetContainerName() . ':develop';
-        } else {
-            return $container->GetContainerName() . ':latest';
-        }
+        return $container->GetContainerName() . ':' . $this->GetCurrentChannel();
     }
 
     public function GetContainerRunningState(Container $container) : IContainerState
@@ -79,12 +74,7 @@ class DockerActionManager
 
     public function GetContainerUpdateState(Container $container) : IContainerState
     {
-        $channel = $this->GetCurrentChannel();
-        if ($channel === 'develop') {
-            $tag = 'develop';
-        } else {
-            $tag = 'latest';
-        }
+        $tag = $this->GetCurrentChannel();
 
         $runningDigest = $this->GetRepoDigestOfContainer($container->GetIdentifier());
         $remoteDigest = $this->dockerHubManager->GetLatestDigestOfTag($container->GetContainerName(), $tag);
@@ -350,12 +340,7 @@ class DockerActionManager
         $imageName = 'nextcloud/all-in-one';
         $containerName = 'nextcloud-aio-mastercontainer';
 
-        $channel = $this->GetCurrentChannel();
-        if ($channel === 'develop') {
-            $tag = 'develop';
-        } else {
-            $tag = 'latest';
-        }
+        $tag = $this->GetCurrentChannel();
 
         $runningDigest = $this->GetRepoDigestOfContainer($containerName);
         $remoteDigest = $this->dockerHubManager->GetLatestDigestOfTag($imageName, $tag);


### PR DESCRIPTION
Related to #28
Instead of manually building the images, this github action will build all the docker images on every push to the main branch and publish them to dockerhub. 

- Only pushes into the **development** tag (not the latest)
- Build the images for multiple architechtures: **amd64** and **arm64**
- Some builds for arm64 images don't work yet. I also have not tested on arm64 yet.
- Needs DOCKERHUB_USERNAME and DOCKERHUB_TOKEN configured as secret
- Here's how the jobs look like: https://github.com/pestotoast/all-in-one/actions/runs/1536966830
- Here's how it looks when pushed to dockerhub: https://hub.docker.com/u/agebhart