### PR TITLE
fix docker permissions, check if docker GID already exists 

### DIFF
--- a/Containers/mastercontainer/start.sh
+++ b/Containers/mastercontainer/start.sh
@@ -15,19 +15,18 @@ elif ! mountpoint -q "/mnt/docker-aio-config"; then
     exit 1
 elif ! sudo -u www-data test -r /var/run/docker.sock; then
     echo "Trying to fix docker.sock permissions internally..."
-
     DOCKER_GROUP=$(stat -c '%G' /var/run/docker.sock)
     DOCKER_GROUP_ID=$(stat -c '%g' /var/run/docker.sock)
-    # check if a group with the same group id of /var/run/docker.socket already exists in the container
+    # Check if a group with the same group id of /var/run/docker.socket already exists in the container
     if grep -q "^$DOCKER_GROUP:" /etc/group; then
-            #if yes, add www-data to that group
-            echo "Adding internal www-data to group $DOCKER_GROUP"
-            usermod -aG "$DOCKER_GROUP" www-data
-        else
-            #if the group doesn't exist, create it
-            echo "Creating docker group internally with id $DOCKER_GROUP_ID"
-            groupadd -g "$DOCKER_GROUP_ID" docker
-            usermod -aG docker www-data
+        # If yes, add www-data to that group
+        echo "Adding internal www-data to group $DOCKER_GROUP"
+        usermod -aG "$DOCKER_GROUP" www-data
+    else
+        # If the group doesn't exist, create it
+        echo "Creating docker group internally with id $DOCKER_GROUP_ID"
+        groupadd -g "$DOCKER_GROUP_ID" docker
+        usermod -aG docker www-data
     fi
     if ! sudo -u www-data test -r /var/run/docker.sock; then
         echo "Docker socket is not readable by the www-data user. Cannot continue."

--- a/Containers/mastercontainer/start.sh
+++ b/Containers/mastercontainer/start.sh
@@ -15,9 +15,20 @@ elif ! mountpoint -q "/mnt/docker-aio-config"; then
     exit 1
 elif ! sudo -u www-data test -r /var/run/docker.sock; then
     echo "Trying to fix docker.sock permissions internally..."
-    GROUP="$(stat -c '%g' /var/run/docker.sock)"
-    groupadd -g "$GROUP" docker && \
-    usermod -aG docker www-data
+
+    DOCKER_GROUP=$(stat -c '%G' /var/run/docker.sock)
+    DOCKER_GROUP_ID=$(stat -c '%g' /var/run/docker.sock)
+    # check if a group with the same group id of /var/run/docker.socket already exists in the container
+    if grep -q "^$DOCKER_GROUP:" /etc/group; then
+            #if yes, add www-data to that group
+            echo "Adding internal www-data to group $DOCKER_GROUP"
+            usermod -aG "$DOCKER_GROUP" www-data
+        else
+            #if the group doesn't exist, create it
+            echo "Creating docker group internally with id $DOCKER_GROUP_ID"
+            groupadd -g "$DOCKER_GROUP_ID" docker
+            usermod -aG docker www-data
+    fi
     if ! sudo -u www-data test -r /var/run/docker.sock; then
         echo "Docker socket is not readable by the www-data user. Cannot continue."
         exit 1

--- a/Containers/watchtower/start.sh
+++ b/Containers/watchtower/start.sh
@@ -5,14 +5,8 @@ if ! [ -a "/var/run/docker.sock" ]; then
     echo "Docker socket is not available. Cannot continue."
     exit 1
 elif ! test -r /var/run/docker.sock; then
-    echo "Trying to fix docker.sock permissions internally..."
-    GROUP="$(stat -c '%g' /var/run/docker.sock)"
-    groupadd -g "$GROUP" docker && \
-    usermod -aG docker root
-    if ! test -r /var/run/docker.sock; then
-        echo "Docker socket is not readable by the root user. Cannot continue."
-        exit 1
-    fi
+    echo "Docker socket is not readable by the root user. Cannot continue."
+    exit 1
 fi
 
 if [ -n "$CONTAINER_TO_UPDATE" ]; then


### PR DESCRIPTION
Should fix https://github.com/nextcloud/all-in-one/issues/10#issuecomment-985895684

Check if a group already exists that has the same groupid as `/var/run/docker.socket` and adjust permissions accordingly

Signed-off-by: Adrian Gebhart <adrian@pestotoast.de>