### PR TITLE
don't crash during container removal if the container doesn't exist

### DIFF
--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -125,7 +125,11 @@ class DockerActionManager
         $url = $this->BuildApiUrl(sprintf('containers/%s', urlencode($container->GetIdentifier())));
         try {
             $this->guzzleClient->delete($url);
-        } catch (\Exception $e) {}
+        } catch (ClientException $e) {
+            if ($e->getCode() !== 404) {
+                throw $e;
+            }
+        }
     }
 
     public function GetLogs(Container $container) : string
@@ -426,7 +430,7 @@ class DockerActionManager
                     ],
                 ]
             );
-        } catch (ServerException $e) {}
+        } catch (ClientException $e) {}
     }
 
     private function ConnectContainerIdToNetwork(string $id)
@@ -482,7 +486,9 @@ class DockerActionManager
 
     public function StopContainer(Container $container) {
         $url = $this->BuildApiUrl(sprintf('containers/%s/stop?t=%s', urlencode($container->GetIdentifier()), $container->GetMaxShutdownTime()));
-        $this->guzzleClient->post($url);
+        try {
+            $this->guzzleClient->post($url);
+        } catch (\Exception $e) {}
     }
 
     public function GetBackupcontainerExitCode() : int

--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -125,7 +125,7 @@ class DockerActionManager
         $url = $this->BuildApiUrl(sprintf('containers/%s', urlencode($container->GetIdentifier())));
         try {
             $this->guzzleClient->delete($url);
-        } catch (ClientException $e) {
+        } catch (\GuzzleHttp\Exception\RequestException $e) {
             if ($e->getCode() !== 404) {
                 throw $e;
             }
@@ -430,7 +430,7 @@ class DockerActionManager
                     ],
                 ]
             );
-        } catch (ClientException $e) {}
+        } catch (\GuzzleHttp\Exception\RequestException $e) {}
     }
 
     private function ConnectContainerIdToNetwork(string $id)
@@ -488,7 +488,11 @@ class DockerActionManager
         $url = $this->BuildApiUrl(sprintf('containers/%s/stop?t=%s', urlencode($container->GetIdentifier()), $container->GetMaxShutdownTime()));
         try {
             $this->guzzleClient->post($url);
-        } catch (\Exception $e) {}
+        } catch (\GuzzleHttp\Exception\RequestException $e) {
+            if ($e->getCode() !== 404 && $e->getCode() !== 304) {
+                throw $e;
+            }
+        }
     }
 
     public function GetBackupcontainerExitCode() : int


### PR DESCRIPTION
This is best reviewed like this: https://github.com/nextcloud/all-in-one/pull/96/files?diff=unified&w=1

Fix #95

Signed-off-by: szaimen <szaimen@e.mail.de>