### PR TITLE
add version number to the AIO interface

### DIFF
--- a/php/templates/containers.twig
+++ b/php/templates/containers.twig
@@ -16,7 +16,7 @@
     </header>
 
     <div class="content">
-        <h1>Nextcloud AIO Beta</h1>
+        <h1>Nextcloud AIO Beta v0.1.0</h1>
         This is beta software and not production ready.<br><br>
 
         {% set isAnyRunning = false %}


### PR DESCRIPTION
For possible reviewers: no logic at all is based on this version number currently so it is fine to have it hardcoded into the interface for now, imo. When I publish a new all-in-one container, I am going to create a new release then.

Signed-off-by: szaimen <szaimen@e.mail.de>