### PR TITLE
group php dependency updates

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -1,0 +1,39 @@
+name: dependency-updates
+
+on:
+  schedule:
+  - cron:  '00 12 * * *'
+
+jobs:
+  dependency_updates:
+    name: Run dependency update script
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: nanasess/setup-php@master
+      with:
+        php-version: '8.0'
+    - name: Run dependency update script
+      run: |
+        curl -sS https://getcomposer.org/installer | php
+        mv composer.phar /usr/local/bin/composer
+        chmod +x /usr/local/bin/composer
+        cd ./php
+        composer update
+        ALL_LINES="$(composer outdated | grep -v "psr/container")"
+        while [ -n "$ALL_LINES" ]; do
+          CURRENT_LINE="$(echo "$ALL_LINES" | head -1)"
+          composer require "$(echo "$CURRENT_LINE" | awk '{print $1}')" "^$(echo "$CURRENT_LINE" | awk '{print $4}')"
+          ALL_LINES="$(echo "$ALL_LINES" | sed '1d')"
+        done
+        echo "outdated dependencies:
+        $(composer outdated)"
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3
+      with:
+        commit-message: dependency updates
+        signoff: true
+        title: Dependency updates
+        body: Automated dependency updates since dependabot does not support grouped updates
+        labels: dependencies, enhancement
+        milestone: next


### PR DESCRIPTION
It allows manual testing in one run and also easy revert if something should be broken.

Of course if somethings is broken, we need find out which dependency update broke it and how we can fix it but I think it will be much easier to do like this. (as long as we don't have automated tests)

Signed-off-by: szaimen <szaimen@e.mail.de>