### PR TITLE
install postgresql-client in Nextcloud container in order to make Nextclouds Backup app work

### DIFF
--- a/Containers/nextcloud/Dockerfile
+++ b/Containers/nextcloud/Dockerfile
@@ -214,6 +214,7 @@ RUN set -ex; \
         gnupg \
         dirmngr \
         git \
+        postgresql-client \
     ; \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This seems to be needed by Nextclouds Backup App in order to work due to the used library (it needs pg_dump in order to work).
Another possibility would be asking @ArtificialOwl to consider another library...

Close #135

Signed-off-by: szaimen <szaimen@e.mail.de>