### PR TITLE
fix zero file sizes

### DIFF
--- a/Containers/apache/nextcloud.conf
+++ b/Containers/apache/nextcloud.conf
@@ -19,4 +19,8 @@
     <Files ".ht*">
         Require all denied
     </Files>
+
+    # Fix zero file sizes 
+    # See https://github.com/nextcloud/server/issues/3056#issuecomment-954209565
+    SetEnv proxy-sendcl 1
 </VirtualHost>


### PR DESCRIPTION
We are using Apache 2.4.52 so this should work: https://github.com/nextcloud-releases/all-in-one/runs/4966029916?check_suite_focus=true#step:7:188

Signed-off-by: szaimen <szaimen@e.mail.de>