### PR TITLE
set up psalm

### DIFF
--- a/.github/workflows/psalm-analysis.yml
+++ b/.github/workflows/psalm-analysis.yml
@@ -1,0 +1,18 @@
+name: Psalm Analysis
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  psalm:
+    name: Psalm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Psalm
+        uses: docker://ghcr.io/nextcloud/all-in-one-psalm
+        with:
+          composer_ignore_platform_reqs: false
+          relative_dir: php

--- a/.github/workflows/psalm-security.yml
+++ b/.github/workflows/psalm-security.yml
@@ -1,0 +1,25 @@
+name: Psalm Security Analysis
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  psalm:
+    name: Psalm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Psalm
+        uses: docker://ghcr.io/nextcloud/all-in-one-psalm
+        with:
+          relative_dir: php
+          security_analysis: true
+          composer_ignore_platform_reqs: false
+          report_file: results.sarif
+      - name: Upload Security Analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: results.sarif

--- a/php/psalm-baseline.xml
+++ b/php/psalm-baseline.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="dev-master@569e97d5e99c92f0ccd23f3bb39f16f6aa079ed2">
+</files>

--- a/php/psalm.xml
+++ b/php/psalm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<psalm
+	errorLevel="2"
+	resolveFromConfigFile="true"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="https://getpsalm.org/schema/config"
+	xsi:schemaLocation="https://getpsalm.org/schema/config"
+    errorBaseline="psalm-baseline.xml"
+>
+	<projectFiles>
+		<directory name="templates"/>
+		<directory name="src"/>
+		<file name="public/index.php"/>
+	</projectFiles>
+</psalm>


### PR DESCRIPTION
Close #207

- [x] ~~needs https://github.com/psalm/psalm-github-actions/pull/36~~ Unfortunatley the container comes with php 7.4 so it will not work.

See 
```
Problem 1
    - Root composer.json requires php ^8.0 but your php version (7.4.28) does not satisfy that requirement.
  Problem 2
    - Root composer.json requires PHP extension ext-apcu * but it is missing from your system. Install or enable PHP's apcu extension.
  Problem 3
    - psr/log is locked to version 3.0.0 and an update of this package was not requested.
    - psr/log 3.0.0 requires php >=8.0.0 -> your php version (7.4.28) does not satisfy that requirement.
  Problem 4
    - symfony/deprecation-contracts is locked to version v3.0.0 and an update of this package was not requested.
    - symfony/deprecation-contracts v3.0.0 requires php >=8.0.2 -> your php version (7.4.28) does not satisfy that requirement.
  Problem 5
    - symfony/deprecation-contracts v3.0.0 requires php >=8.0.2 -> your php version (7.4.28) does not satisfy that requirement.
    - guzzlehttp/guzzle 7.4.1 requires symfony/deprecation-contracts ^2.2 || ^3.0 -> satisfiable by symfony/deprecation-contracts[v3.0.0].
    - guzzlehttp/guzzle is locked to version 7.4.1 and an update of this package was not requested.
```

Signed-off-by: szaimen <szaimen@e.mail.de>