### PR TITLE
Adding apache port environment variable to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,5 @@ services:
       - 80:80
       - 8080:8080
       - 8443:8443
+    environment:
+      - APACHE_PORT=11000


### PR DESCRIPTION
We compared the startup command from https://github.com/nextcloud/all-in-one/blob/main/reverse-proxy.md to this file and noticed that "-e APACHE_PORT=11000" is not reflected here.
After adding the line, we could progress with our setup.