### PR TITLE
docs: provide context around reverse proxy config

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,8 @@ If your firewall/router has port 80 and 8443 open and you point a domain to your
 Nextcloud AIO is inspired by projects like Portainer that allow to manage the docker daemon by talking to the docker socket directly. This concept allows to install only one container with a single command that does the heavy lifting of creating and managing all containers that are needed in order to provide a Nextcloud installation with most features included. It also makes updating a breeze and is not bound to the host system (and its slow updates) anymore as everything is in containers. Additionally, it is very easy to handle from a user perspective because a simple interface for managing your Nextcloud AIO installation is provided.
 
 ### Are reverse proxies supported?
-Yes. Please refer to the following documentation on this: [reverse-proxy.md](https://github.com/nextcloud/all-in-one/blob/main/reverse-proxy.md)
+Yes. `nextcloud/all-in-one` assumes that your reverse proxy is installed directly on the host, not inside a separate docker container.
+Please refer to the following documentation on this: [reverse-proxy.md](https://github.com/nextcloud/all-in-one/blob/main/reverse-proxy.md)
 
 ### Which ports are mandatory to be open in your firewall/router?
 Only those (if you acces the Mastercontainer Interface internally via port 8080):

--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -1,5 +1,7 @@
 ## Reverse Proxy Documentation
 
+**ℹ️ INFO:** `nextcloud/all-in-one` assumes that your reverse proxy is installed directly on the host, not inside a separate docker container.
+
 Basically, you need to specify the port that the apache container shall use and modify the startup command a bit.
 
 All examples below will use port `11000` as example apache port. Also it is supposed that the reverse proxy runs on the same server like AIO, hence `localhost` is used and not an internal ip-address to point to the AIO instance. Modify both to your needings.


### PR DESCRIPTION
I just spent a couple hours learning about `nextcloud-aio` in order to help someone debug their nextcloud-aio deployment. they were trying to use `nextcloud-aio` with a caddy reverse proxy docker container on a custom docker network.  It wasn't working because nextcloud-aio spawns an auxiliary `domaincheck` container on the default docker network and maps the APACHE_PORT to the host.  

But the user's reverse proxy docker container cannot dial the  `domaincheck` container because its on a different docker network, and the  reverse proxy docker container can't dial the host (or, at least, the user never figured out how) 


The docs need to provide context around the instructions, if the user is allowed to make assumptions about what contexts the instructions are valid in, they will try to do all kinds of stuff which wont work, resulting in failure, frustrated users.