### PR TITLE
Fixed WebDav Uploads in Nginx

### DIFF
--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -49,6 +49,7 @@ location / {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        client_max_body_size 0;
 
         # Websocket
         proxy_http_version 1.1;


### PR DESCRIPTION
Signed-off-by: Marek Schneider <marek@kms.onl>

Uploads using the Nextcloud Sync Client larger than 1 MB violate the default Nginx client_max_body_size policy. A "413 Request Entity Too Large" will occur. Setting the value to 0 will solve the problem.