### PR TITLE
set AIO_URL port to 443 if port 8000 was discovered

### DIFF
--- a/php/src/Controller/DockerController.php
+++ b/php/src/Controller/DockerController.php
@@ -132,6 +132,10 @@ class DockerController
         $uri = $request->getUri();
         $host = $uri->getHost();
         $port = $uri->getPort();
+        if ($port === 8000) {
+            error_log('The AIO_URL-port was discovered to be 8000 which is not expected. It is now set to 443.');
+            $port = 443;
+        }
 
         $config = $this->configurationManager->GetConfig();
         // set AIO_URL


### PR DESCRIPTION
Fix https://github.com/nextcloud/all-in-one/issues/673

Signed-off-by: szaimen <szaimen@e.mail.de>