### PR TITLE
allow to lock the backup archive for external scripts

### DIFF
--- a/Containers/borgbackup/backupscript.sh
+++ b/Containers/borgbackup/backupscript.sh
@@ -37,6 +37,13 @@ if [ "$BORG_MODE" != backup ] && [ "$BORG_MODE" != test ] && ! [ -f "$BORG_BACKU
     exit 1
 fi
 
+# Do not continue if this file exists (needed for simple external blocking)
+if [ -f "$BORG_BACKUP_DIRECTORY/aio-lockfile" ]; then
+    echo "Not continuing because aio-lockfile exists - it seems like a script is externally running which is locking the backup archive."
+    echo "If this should not be the case, you can fix this by deleting the 'aio-lockfile' file from the backup archive directory."
+    exit 1
+fi
+
 # Create lockfile
 if [ "$BORG_MODE" = backup ] || [ "$BORG_MODE" = restore ]; then
     touch "/nextcloud_aio_volumes/nextcloud_aio_database_dump/backup-is-running"

--- a/readme.md
+++ b/readme.md
@@ -293,10 +293,20 @@ if ! [ -d "$TARGET_DIRECTORY" ]; then
     exit 1
 fi
 
+if [ -f "$SOURCE_DIRECTORY/aio-lockfile" ]; then
+    echo "Not continuing because aio-lockfile already exists."
+    exit 1
+fi
+
+touch "$SOURCE_DIRECTORY/aio-lockfile"
+
 if ! rsync --stats --archive --human-readable --delete "$SOURCE_DIRECTORY/" "$TARGET_DIRECTORY"; then
     echo "Failed to sync the backup repository to the target directory."
     exit 1
 fi
+
+rm "$SOURCE_DIRECTORY/aio-lockfile"
+rm "$TARGET_DIRECTORY/aio-lockfile"
 
 umount "$DRIVE_MOUNTPOINT"
 
@@ -316,8 +326,6 @@ Afterwards apply the correct permissions with `sudo chown root:root /root/backup
 1. Open the cronjob with `sudo crontab -u root -e` (and choose your editor of choice if not already done. I'd recommend nano). 
 1. Add the following new line to the crontab if not already present: `0 20 * * 7 /root/backup-script.sh` which will run the script at 20:00 on Sundays each week. 
 1. save and close the crontab (when using nano are the shortcuts for this `Ctrl + o` -> `Enter` and close the editor with `Ctrl + x`).
-
-⚠️ **Attention:** Make sure that the execution of the script does not collide with the daily backups from AIO (if configured) since the target backup repository might get into an inconsistent state. (There is no check in place that checks this.)
 
 ### How to change the default location of Nextcloud's Datadir?
 You can configure the Nextcloud container to use a specific directory on your host as data directory. You can do so by adding the environmental variable `NEXTCLOUD_DATADIR` to the initial startup of the mastercontainer. Allowed values for that variable are strings that start with `/` and are not equal to `/`.


### PR DESCRIPTION
Close https://github.com/nextcloud/all-in-one/issues/723

todo:
- [x] add hint what you can do if it is locked

Signed-off-by: szaimen <szaimen@e.mail.de>