### PR TITLE
set the interned strings buffer to 32

### DIFF
--- a/Containers/nextcloud/Dockerfile
+++ b/Containers/nextcloud/Dockerfile
@@ -85,7 +85,7 @@ RUN set -ex; \
 # set recommended PHP.ini settings
 # see https://docs.nextcloud.com/server/stable/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
 RUN { \
-        echo 'opcache.interned_strings_buffer=64'; \
+        echo 'opcache.interned_strings_buffer=32'; \
         echo 'opcache.save_comments=1'; \
         echo 'opcache.revalidate_freq=60'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \


### PR DESCRIPTION
Fix https://github.com/nextcloud/all-in-one/pull/791#issuecomment-1157972822

Signed-off-by: szaimen <szaimen@e.mail.de>