### PR TITLE
Improve docs for Cloudflare Tunnel setup

### DIFF
--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -99,7 +99,7 @@ Of course you need to modify `<your-nc-domain>` to the domain on which you want 
 
 Although it does not seems like it is the case but from AIO perspective a Cloudflare Argo Tunnel works like a reverse proxy. Here is how to make it work:
 
-1. Install the Cloudflare Argo Tunnel on the same machine where AIO will be running on and point the Argo Tunnel with the domain that you want to use for AIO to `localhost:11000`. If the Argo Tunnel is running on a different machine, you can alternatively instead of `localhost` use the ip-address that is displayed after running the following command on the host OS: `ip a | grep "scope global" | head -1 | awk '{print $2}' | sed 's|/.*||'` (the command only works on Linux)
+1. Install the Cloudflare Argo Tunnel on the same machine where AIO will be running on and point the Argo Tunnel with the domain that you want to use for AIO to `http://localhost:11000`. If the Argo Tunnel is running on a different machine, you can alternatively instead of `localhost` use the ip-address that is displayed after running the following command on the host OS: `ip a | grep "scope global" | head -1 | awk '{print $2}' | sed 's|/.*||'` (the command only works on Linux)
 2. Now continue with [point 2](#2-use-this-startup-command) but additionally, add `-e SKIP_DOMAIN_VALIDATION=true` to the docker run command which will disable the dommain validation (because it is known that the domain validation will not work behind a Cloudflare Argo Tunnel). So you need to ensure yourself that you've configured everything correctly.
 
 </details>


### PR DESCRIPTION
I ran into an issue during my setup where I set up my Cloudflare Tunnel's configuration to point to `https://localhost:11000` instead of `http://localhost:11000` (due to another program I'm using requiring the opposite). This created a multitude of issues which I found challenging to debug. 

As such, I am proposing that the configuration specifies to make the tunnel use `http` instead of `https` to avoid confusion for other users.

If maintainers think that the project would benefit from it, I can also add in an example `config.json` that others can adapt to mk the setup process simpler for those who are newer to self-hosting.