### PR TITLE
Fixes small typo in multiple-instances.md

### DIFF
--- a/multiple-instances.md
+++ b/multiple-instances.md
@@ -1,13 +1,13 @@
 # Multiple AIO instances
 It is possible to run multiple instances of AIO on one server.
 
-There are two ways to achieve this: The normal way is creating multiple VMs, installing AIO in [reverse proxy mode](./reverse-proxy.md) in each of them and having one reverse proxy in front of them that points to each VM (you also need to use a different `TALK_PORT` for each of them). The second and more advanced way is creating multiple users on the server and using docker rootles for each of them in order to install multiple instances on the same server. 
+There are two ways to achieve this: The normal way is creating multiple VMs, installing AIO in [reverse proxy mode](./reverse-proxy.md) in each of them and having one reverse proxy in front of them that points to each VM (you also need to use a different `TALK_PORT` for each of them). The second and more advanced way is creating multiple users on the server and using docker rootless for each of them in order to install multiple instances on the same server. 
 
 Below is described more in detail how the the second way works.
 
 ## Run multiple AIO instances on the same server with docker rootless
 1. Create as many linux users as you need first. The easiest way is to use `sudo adduser` and follow the setup for that. Make sure to create a strong unique password for each of them and write it down!
-1. Log in as each of the users e.g. by opening a new SSH connection and install docker rootles for each of them by following step 0-4 of the [docker rootles documentation](./docker-rootless.md).
+1. Log in as each of the users e.g. by opening a new SSH connection and install docker rootless for each of them by following step 0-4 of the [docker rootless documentation](./docker-rootless.md).
 1. Then install AIO in reverse proxy mode by using the command that is descriebed in step 2 and 3 of the [reverse proxy documentation](./reverse-proxy.md) but use a different `APACHE_PORT` and `TALK_PORT` for each instance as otherwise it will bug out. Also make sure to adjust the docker socket and `DOCKER_SOCKET_PATH` correctly for each of them by following step 6 of the [docker rootless documentation](./docker-rootless.md). Additionally, modify `-p 8080:8080` to a different port for each container, e.g. `8081:8080` as otherwise it will not work.<br>
 **⚠️ Please note:** If you want to adjust the `NEXTCLOUD_DATADIR`, make sure to apply the correct permissions to the chosen path as documented at the bottom of the [docker rootless documentation](./docker-rootless.md). Also for the built-in backup to work, the target path needs to have the correct permissions as documented there, too.
 1. Now install your webserver of choice on the host system. It is recommended to use caddy for this as it is by far the easiest solution. You can do so by following https://caddyserver.com/docs/install#debian-ubuntu-raspbian or below. (It needs to be installed directly on the host or on a different server in the same network).


### PR DESCRIPTION
Fixes small typo in multiple-instances.md: "rootles" must be "rootless"

Signed-off-by: Fernando Ribeiro <fribeiro@fribeiro.org>