### PR TITLE
Grammar fix: Replace "loose" with "lose"

### DIFF
--- a/manual-install/readme.md
+++ b/manual-install/readme.md
@@ -7,9 +7,9 @@ You can run the containers that are build for AIO with docker-compose. This come
 - You can modify all values on your own
 
 ### Disadvantages
-- You loose the AIO interface
-- You loose update notifications and automatic updates
-- You loose all AIO backup and restore features
+- You lose the AIO interface
+- You lose update notifications and automatic updates
+- You lose all AIO backup and restore features
 - You need to know what you are doing, especially when modifying the docker-compose file
 - Probably more
 

--- a/php/templates/containers.twig
+++ b/php/templates/containers.twig
@@ -346,7 +346,7 @@
                                 {% endif %}
                                 <h3>Backup information</h3>
                                 This is your encryption password for backups: <b>{{ borgbackup_password }}</b><br /><br/>
-                                Please save it at a safe place since you won't be able to restore from backup if you loose this password! <br /><br/>
+                                Please save it at a safe place since you won't be able to restore from backup if you lose this password! <br /><br/>
                                 Backed up will get all important data of your Nextcloud AIO instance like the database, your files and configuration files of the mastercontainer and else. <br /><br/>
                                 The backup itself will use a tool that is called <a href="https://github.com/borgbackup/borg#what-is-borgbackup"><b>BorgBackup</b><a/> which is a well-known server backup tool that efficiently backs up your files and encrypts them on the fly. <br /><br/>
                                 Backups get created in the following directory on the host: <b>{{ borg_backup_host_location }}/borg</b> <br /><br/>

--- a/php/templates/setup.twig
+++ b/php/templates/setup.twig
@@ -6,7 +6,7 @@
             <img src="/img/logo-blue.svg" style="margin-left: auto;margin-right: auto;display: block;">
             <h1>Nextcloud AIO setup</h1>
             <p>Nextcloud AIO stands for Nextcloud All In One and provides easy deployment and maintenance with most features included in this one Nextcloud instance.</p>
-            <p>Please note down the password to access the AIO interface and don't loose it!</p>
+            <p>Please note down the password to access the AIO interface and don't lose it!</p>
             <strong>Password</strong><br/> <span class="monospace">{{ password }}</span><br>
             <a href="/" class="button" target="_blank" rel="noopener">Open Nextcloud AIO login ↗</a>
         </div>


### PR DESCRIPTION
This replaces a few instances of "loose" with "lose", which is grammatically correct in these contexts.