### PR TITLE
Set default talk port inside Dockerfile

### DIFF
--- a/Containers/talk/Dockerfile
+++ b/Containers/talk/Dockerfile
@@ -61,6 +61,9 @@ RUN mkdir -p /etc/nats; \
 # Give root a random password
 RUN echo "root:$(openssl rand -base64 12)" | chpasswd
 
+# Set default talk port https://github.com/nextcloud/all-in-one/issues/1011
+ENV TALK_PORT=3478
+
 USER talk
 ENTRYPOINT ["start.sh"]
 CMD ["/usr/bin/supervisord", "-c", "/supervisord.conf"]


### PR DESCRIPTION
Should close https://github.com/nextcloud/all-in-one/issues/1011, because so the default env is set and when the talk container is launched by the mastercontainer, the env should be overridden by the env send from the mastercontainer.
If I have an image with an env (myenv=456) set inside the Dockerfile and then launch it with "-e myenv=123" the env is set to 123 inside the container,
I hope it's the same when the container is launched through the docker socket. But if yes, this change should help.

Signed-off-by: Zoey <zoey@z0ey.de>