### PR TITLE
Fix bad error message in start.sh

### DIFF
--- a/Containers/talk/start.sh
+++ b/Containers/talk/start.sh
@@ -11,7 +11,7 @@ elif [ -z "$JANUS_API_KEY" ]; then
     echo "You need to provide the JANUS_API_KEY."
     exit 1
 elif [ -z "$SIGNALING_SECRET" ]; then
-    echo "You need to provide the JANUS_API_KEY."
+    echo "You need to provide the SIGNALING_SECRET."
     exit 1
 fi
 


### PR DESCRIPTION
Fix bad error message in start.sh which seems to be a copy/paste error from the previous if check.

Signed-off-by: Florian Latifi <mail@florian-latifi.at>