### PR TITLE
Typo: X-Robot-Tag should be X-Robots-Tags

### DIFF
--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -239,7 +239,7 @@ Of course you need to modify `<your-nc-domain>` to the domain on which you want 
             hostsProxyHeaders = ["X-Forwarded-Host"]
             sslRedirect = true
             referrerPolicy = "same-origin"
-            X-Robots-Tag = "none"
+            X-Robots-Tags = "none"
     ```
 
 3. Add to the bottom of the `middleware-chains.toml` file in the Traefik rules folder the following content:


### PR DESCRIPTION
X-Robots-Tag does not exist, X-Robots-Tags is the correct syntax

Signed-off-by: Matthieu B <66959271+mtthidoteu@users.noreply.github.com>