### PR TITLE
aio-apache configuration now uses NEXTCLOUD_HOST env variable (#1173)

### DIFF
--- a/Containers/apache/nextcloud.conf
+++ b/Containers/apache/nextcloud.conf
@@ -2,7 +2,7 @@ Listen 8000
 <VirtualHost *:8000>
     # PHP match
     <FilesMatch "\.php$">
-        SetHandler "proxy:fcgi://nextcloud-aio-nextcloud:9000"
+        SetHandler "proxy:fcgi://${NEXTCLOUD_HOST}:9000"
     </FilesMatch>
     # Nextcloud dir
     DocumentRoot /var/www/html/


### PR DESCRIPTION
instead of hardcoded container name

This PR resolves #1173 by replacing the hardcoded hostname of the `nextcloud-aio-nextcloud` container by the already existing `NEXTCLOUD_HOST` env variable.

Built apache image locally and verified that it's indeed working for a different container name.  