### PR TITLE
rework NGINX reverse proxy docs to support CODE

### DIFF
--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -240,7 +240,7 @@ server {
     listen 443 ssl;
     server_name <your-nc-domain>;
     location / {
-        proxy_pass http://localhost:11000;
+        proxy_pass http://localhost:11000$request_uri;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
As per PR #1236, applied the same documentation change to the NGINX configuration, so as to pass the full URI of each HTTP request to the Collabora Online backend. This fixes #834 but for NGINX rather than Apache. It might be necessary to make similar changes to other proxy software, but NGINX is what I am familiar with.

Signed-off-by: TheManchineel <37479927+TheManchineel@users.noreply.github.com>