### PR TITLE
imaginary - add `-return-size` option by default

### DIFF
--- a/Containers/imaginary/Dockerfile
+++ b/Containers/imaginary/Dockerfile
@@ -13,4 +13,6 @@ RUN set -ex; \
     rm -rf /var/lib/apt/lists/*
 USER nobody
 
+ENTRYPOINT ["/usr/local/bin/imaginary", "-return-size"]
+
 HEALTHCHECK CMD nc -z localhost 9000 || exit 1


### PR DESCRIPTION
Address https://github.com/nextcloud/previewgenerator/issues/323#issuecomment-1311703385

After release, merge https://github.com/nextcloud/documentation/pull/9373

Signed-off-by: Simon L <szaimen@e.mail.de>