### PR TITLE
add a hint what to do if the backup container was forcefully killed

### DIFF
--- a/Containers/postgresql/start.sh
+++ b/Containers/postgresql/start.sh
@@ -9,6 +9,8 @@ export PGPASSWORD="$POSTGRES_PASSWORD"
 # Don't start database as long as backup is running
 while [ -f "$DUMP_DIR/backup-is-running" ]; do
     echo "Waiting for backup container to finish..."
+    echo "If this is incorrect because the backup container is not running anymore (because it was forcefully killed), you might delete the lock file which is by default stored here:"
+    echo "/var/lib/docker/volumes/nextcloud_aio_database_dump/_data/backup-is-running"
     sleep 10
 done
 


### PR DESCRIPTION
Get rid of questions like https://github.com/nextcloud/all-in-one/discussions/1469

Signed-off-by: Simon L <szaimen@e.mail.de>