### PR TITLE
remove pdo_mysql

### DIFF
--- a/Containers/nextcloud/Dockerfile
+++ b/Containers/nextcloud/Dockerfile
@@ -53,7 +53,6 @@ RUN set -ex; \
         ldap \
         opcache \
         pcntl \
-        pdo_mysql \
         pdo_pgsql \
         zip \
         gmp \


### PR DESCRIPTION
Close https://github.com/nextcloud/all-in-one/issues/1191

sqlite is included by default so is not needed to be added manually

Signed-off-by: Simon L <szaimen@e.mail.de>