### PR TITLE
also back up the fulltextsearch volume

### DIFF
--- a/Containers/borgbackup/backupscript.sh
+++ b/Containers/borgbackup/backupscript.sh
@@ -66,7 +66,7 @@ if [ "$BORG_MODE" = backup ]; then
 
     # Test that nothing is empty
     for directory in "${VOLUME_DIRS[@]}"; do
-        if [ -z "$(ls -A "$directory")" ]; then
+        if [ -z "$(ls -A "$directory")" ] && [ "$directory" != "/nextcloud_aio_volumes/nextcloud_aio_elasticsearch" ]; then
             echo "$directory is empty which is not allowed."
             exit 1
         fi

--- a/Containers/borgbackup/backupscript.sh
+++ b/Containers/borgbackup/backupscript.sh
@@ -258,13 +258,14 @@ if [ "$BORG_MODE" = restore ]; then
 
     # Restore everything except the configuration file
     if ! rsync --stats --archive --human-readable -vv --delete \
-    --exclude "nextcloud_aio_mastercontainer/session/"** \
+    --exclude "nextcloud_aio_apache/caddy/"** \
+    --exclude "nextcloud_aio_elasticsearch" \
+    --exclude "nextcloud_aio_mastercontainer/caddy/"** \
     --exclude "nextcloud_aio_mastercontainer/certs/"** \
+    --exclude "nextcloud_aio_mastercontainer/data/configuration.json" \
     --exclude "nextcloud_aio_mastercontainer/data/daily_backup_running" \
     --exclude "nextcloud_aio_mastercontainer/data/session_date_file" \
-    --exclude "nextcloud_aio_mastercontainer/data/configuration.json" \
-    --exclude "nextcloud_aio_apache/caddy/"** \
-    --exclude "nextcloud_aio_mastercontainer/caddy/"** \
+    --exclude "nextcloud_aio_mastercontainer/session/"** \
     /tmp/borg/nextcloud_aio_volumes/ /nextcloud_aio_volumes; then
         echo "Something failed while restoring from backup."
         umount /tmp/borg

--- a/php/containers.json
+++ b/php/containers.json
@@ -290,6 +290,11 @@
           "name": "%BORGBACKUP_HOST_LOCATION%",
           "location": "/mnt/borgbackup",
           "writeable": true
+        },
+        {
+          "name": "nextcloud_aio_elasticsearch",
+          "location": "/nextcloud_aio_volumes/nextcloud_aio_elasticsearch",
+          "writeable": true
         }
       ],
       "secrets": [


### PR DESCRIPTION
Signed-off-by: Simon L <szaimen@e.mail.de>

- [x] todo: need to test if restoring old backup to thid version works (as rsync will not be able to delete the fulltextsearch mountpoint) -> possibly need to add some logic to skip deleting the folder... Maybe with exclude?