### PR TITLE
added redis volume to manual-install docker compose

### DIFF
--- a/manual-install/latest-arm64.yml
+++ b/manual-install/latest-arm64.yml
@@ -105,6 +105,8 @@ services:
   nextcloud-aio-redis:
     container_name: nextcloud-aio-redis
     image: nextcloud/aio-redis:latest-arm64
+    volumes:
+      - nextcloud_aio_redis:/data:rw
     environment:
       - REDIS_HOST_PASSWORD=${REDIS_PASSWORD}
       - TZ=${TIMEZONE}
@@ -198,6 +200,8 @@ volumes:
     name: nextcloud_aio_onlyoffice
   nextcloud_aio_nextcloud_data:
     name: nextcloud_aio_nextcloud_data
+  nextcloud_aio_redis:
+    name: nextcloud_aio_redis
 
 networks:
   nextcloud-aio:

--- a/manual-install/latest.yml
+++ b/manual-install/latest.yml
@@ -108,6 +108,8 @@ services:
   nextcloud-aio-redis:
     container_name: nextcloud-aio-redis
     image: nextcloud/aio-redis:latest
+    volumes:
+      - nextcloud_aio_redis:/data:rw
     environment:
       - REDIS_HOST_PASSWORD=${REDIS_PASSWORD}
       - TZ=${TIMEZONE}
@@ -215,6 +217,8 @@ volumes:
     name: nextcloud_aio_onlyoffice
   nextcloud_aio_nextcloud_data:
     name: nextcloud_aio_nextcloud_data
+  nextcloud_aio_redis:
+    name: nextcloud_aio_redis
 
 networks:
   nextcloud-aio:


### PR DESCRIPTION
Hey @szaimen!

I saw that you've added a volume for the redis container in 882fd3be26d177db2271922770f018b7ebfef725. 
You forgot to add that volume for the manual install docker compose files. I've done that in this PR.