### PR TITLE
add gcompat for the recognize app

### DIFF
--- a/Containers/nextcloud/Dockerfile
+++ b/Containers/nextcloud/Dockerfile
@@ -199,6 +199,7 @@ RUN set -ex; \
         sudo \
         grep \
         coreutils \
+        gcompat \
     ; \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
It is needed for the recognize app IIRC.

Signed-off-by: Simon L <szaimen@e.mail.de>