### PR TITLE
change domaincheck container to unless-stopped

### DIFF
--- a/php/containers.json
+++ b/php/containers.json
@@ -347,7 +347,7 @@
         "INSTANCE_ID"
       ],
       "stop_grace_period": 1,
-      "restart": ""
+      "restart": "unless-stopped"
     },
     {
       "container_name": "nextcloud-aio-clamav",


### PR DESCRIPTION
This may not fix https://github.com/nextcloud/all-in-one/discussions/1608 but at least it will get shown in running containers then and as restarting...

Signed-off-by: Simon L <szaimen@e.mail.de>