### PR TITLE
Add Parameter NC_WEBROOT to configure subdirectory of nextcloud

### DIFF
--- a/Containers/apache/Caddyfile
+++ b/Containers/apache/Caddyfile
@@ -8,17 +8,25 @@
 
 {$PROTOCOL}://{$NC_DOMAIN}:{$APACHE_PORT} {
 
+    # well-known
+    redir /.well-known/carddav {$NC_WEBROOT_P}/remote.php/dav
+    redir /.well-known/caldav {$NC_WEBROOT_P}/remote.php/dav
+    redir /.well-known/webdav {$NC_WEBROOT_P}/remote.php/dav
+    redir /.well-known/webfinger {$NC_WEBROOT_P}/index.php/.well-known/webfinger
+    redir /.well-known/nodeinfo {$NC_WEBROOT_P}/index.php/.well-known/nodeinfo
+
+
     # Notify Push
-    route /push/* {
-        uri strip_prefix /push
+    route {$NC_WEBROOT_P}/push/* {
+        uri strip_prefix {$NC_WEBROOT_P}/push
         reverse_proxy {$NEXTCLOUD_HOST}:7867 {
             # trusted_proxies placeholder
         }
     }
 
     # Talk
-    route /standalone-signaling/* {
-        uri strip_prefix /standalone-signaling
+    route {$NC_WEBROOT_P}/standalone-signaling/* {
+        uri strip_prefix {$NC_WEBROOT_P}/standalone-signaling
         reverse_proxy {$TALK_HOST}:8081 {
             # trusted_proxies placeholder
         }
@@ -42,19 +50,18 @@
     }
 
     # Onlyoffice
-    route /onlyoffice/* {
-        uri strip_prefix /onlyoffice
+    route {$NC_WEBROOT_P}/onlyoffice/* {
+        uri strip_prefix {$NC_WEBROOT_P}/onlyoffice
         reverse_proxy {$ONLYOFFICE_HOST}:80 {
-            header_up X-Forwarded-Host {http.request.host}/onlyoffice
+            header_up X-Forwarded-Host {http.request.host}{$NC_WEBROOT_P}/onlyoffice
             header_up X-Forwarded-Proto https
             # trusted_proxies placeholder
         }
     }
 
     # Nextcloud
-    route {
-        rewrite /.well-known/carddav /remote.php/dav
-        rewrite /.well-known/caldav /remote.php/dav
+    route {$NC_WEBROOT_P}/* {
+        # uri_strip_webroot placeholder
         header Strict-Transport-Security max-age=31536000;
         reverse_proxy localhost:8000 {
             # See https://github.com/nextcloud/all-in-one/issues/828

--- a/Containers/apache/start.sh
+++ b/Containers/apache/start.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Build NC_WEBROOT_P
+export NC_WEBROOT_P=$([  "$NC_WEBROOT" = "/" ] && echo "" || echo "$NC_WEBROOT")
+
 if [ -z "$NC_DOMAIN" ]; then
     echo "NC_DOMAIN and NEXTCLOUD_HOST need to be provided. Exiting!"
     exit 1
@@ -44,6 +47,12 @@ else
     CADDYFILE="$(sed 's|trusted_proxies private_ranges|# trusted_proxies placeholder|' /Caddyfile)"
 fi
 echo "$CADDYFILE" > /Caddyfile
+
+# Strip uri prefix, if NC_WEBROOT
+if [ "$NC_WEBROOT_P" != '' ]; then
+    CADDYFILE="$(sed 's|# uri_strip_webroot placeholder|uri strip_prefix {$NC_WEBROOT_P}|' /Caddyfile)"
+    echo "$CADDYFILE" > /Caddyfile
+fi
 
 # Add caddy path
 mkdir -p /mnt/data/caddy/

--- a/Containers/nextcloud/entrypoint.sh
+++ b/Containers/nextcloud/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Build NC_WEBROOT_P
+export NC_WEBROOT_P=$([  "$NC_WEBROOT" = "/" ] && echo "" || echo "$NC_WEBROOT")
+
 # version_greater A B returns whether A > B
 version_greater() {
     [ "$(printf '%s\n' "$@" | sort -t '.' -n -k1,1 -k2,2 -k3,3 -k4,4 | head -n 1)" != "$1" ]
@@ -385,7 +388,8 @@ php /var/www/html/occ config:app:set admin_audit logfile --value="/var/www/html/
 # Apply network settings
 echo "Applying network settings..."
 php /var/www/html/occ config:system:set trusted_domains 1 --value="$NC_DOMAIN"
-php /var/www/html/occ config:system:set overwrite.cli.url --value="https://$NC_DOMAIN/"
+php /var/www/html/occ config:system:set overwrite.cli.url --value="https://${NC_DOMAIN}${NC_WEBROOT_P}"
+php /var/www/html/occ config:system:set overwritewebroot --value="${NC_WEBROOT_P}"
 php /var/www/html/occ config:system:set htaccess.RewriteBase --value="/"
 php /var/www/html/occ maintenance:update:htaccess
 
@@ -413,7 +417,7 @@ elif [ "$SKIP_UPDATE" != 1 ]; then
 fi
 php /var/www/html/occ config:system:set trusted_proxies 0 --value="127.0.0.1"
 php /var/www/html/occ config:system:set trusted_proxies 1 --value="::1"
-php /var/www/html/occ config:app:set notify_push base_endpoint --value="https://$NC_DOMAIN/push"
+php /var/www/html/occ config:app:set notify_push base_endpoint --value="https://${NC_DOMAIN}${NC_WEBROOT_P}/push"
 
 # Collabora
 if [ "$COLLABORA_ENABLED" = 'yes' ]; then
@@ -424,7 +428,7 @@ if [ "$COLLABORA_ENABLED" = 'yes' ]; then
     elif [ "$SKIP_UPDATE" != 1 ]; then
         php /var/www/html/occ app:update richdocuments
     fi
-    php /var/www/html/occ config:app:set richdocuments wopi_url --value="https://$NC_DOMAIN/"
+    php /var/www/html/occ config:app:set richdocuments wopi_url --value="https://$NC_DOMAIN${NC_WEBROOT_P}"
     # Fix https://github.com/nextcloud/all-in-one/issues/188:
     php /var/www/html/occ config:system:set allow_local_remote_servers --type=bool --value=true
     # Make collabora more save
@@ -486,7 +490,7 @@ if [ "$ONLYOFFICE_ENABLED" = 'yes' ]; then
     fi
     php /var/www/html/occ config:system:set onlyoffice jwt_secret --value="$ONLYOFFICE_SECRET"
     php /var/www/html/occ config:system:set onlyoffice jwt_header --value="AuthorizationJwt"
-    php /var/www/html/occ config:app:set onlyoffice DocumentServerUrl --value="https://$NC_DOMAIN/onlyoffice"
+    php /var/www/html/occ config:app:set onlyoffice DocumentServerUrl --value="https://${NC_DOMAIN}${NC_WEBROOT_P}/onlyoffice"
     php /var/www/html/occ config:system:set allow_local_remote_servers --type=bool --value=true
 else
     if [ -d "/var/www/html/custom_apps/onlyoffice" ] && [ -n "$ONLYOFFICE_SECRET" ] && [ "$(php /var/www/html/occ config:system:get onlyoffice jwt_secret)" = "$ONLYOFFICE_SECRET" ]; then
@@ -511,8 +515,8 @@ if [ "$TALK_ENABLED" = 'yes' ]; then
         php /var/www/html/occ talk:stun:add "$NC_DOMAIN:$TALK_PORT"
         php /var/www/html/occ talk:stun:delete "stun.nextcloud.com:443"
     fi
-    if ! php /var/www/html/occ talk:signaling:list --output="plain" | grep -q "https://$NC_DOMAIN/standalone-signaling/"; then
-        php /var/www/html/occ talk:signaling:add "https://$NC_DOMAIN/standalone-signaling/" "$SIGNALING_SECRET" --verify
+    if ! php /var/www/html/occ talk:signaling:list --output="plain" | grep -q "https://${NC_DOMAIN}${NC_WEBROOT_P}/standalone-signaling/"; then
+        php /var/www/html/occ talk:signaling:add "https://${NC_DOMAIN}${NC_WEBROOT_P}/standalone-signaling/" "$SIGNALING_SECRET" --verify
     fi
 else
     if [ -d "/var/www/html/custom_apps/spreed" ]; then

--- a/Containers/talk/start.sh
+++ b/Containers/talk/start.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Build NC_WEBROOT_P
+export NC_WEBROOT_P=$([  "$NC_WEBROOT" = "/" ] && echo "" || echo "$NC_WEBROOT")
+
 # Variables
 if [ -z "$NC_DOMAIN" ]; then
     echo "You need to provide the NC_DOMAIN."
@@ -72,7 +75,7 @@ timeout = 10
 connectionsperhost = 8
 
 [backend-1]
-url = https://${NC_DOMAIN}
+url = https://${NC_DOMAIN}${NC_WEBROOT_P}
 secret = ${SIGNALING_SECRET}
 
 [nats]

--- a/manual-install/latest.yml
+++ b/manual-install/latest.yml
@@ -12,6 +12,7 @@ services:
       - ${APACHE_IP_BINDING}:${APACHE_PORT}:${APACHE_PORT}/tcp
     environment:
       - NC_DOMAIN=${NC_DOMAIN}
+      - NC_WEBROOT=${NC_WEBROOT}
       - NEXTCLOUD_HOST=nextcloud-aio-nextcloud
       - COLLABORA_HOST=nextcloud-aio-collabora
       - TALK_HOST=nextcloud-aio-talk
@@ -65,6 +66,7 @@ services:
       - REDIS_HOST_PASSWORD=${REDIS_PASSWORD}
       - AIO_TOKEN=${AIO_TOKEN}
       - NC_DOMAIN=${NC_DOMAIN}
+      - NC_WEBROOT=${NC_WEBROOT}
       - ADMIN_USER=admin
       - ADMIN_PASSWORD=${NEXTCLOUD_PASSWORD}
       - NEXTCLOUD_DATA_DIR=/mnt/ncdata
@@ -115,7 +117,7 @@ services:
     profiles: ["collabora"]
     image: nextcloud/aio-collabora:${IMAGE_TAG}
     environment:
-      - aliasgroup1=https://${NC_DOMAIN}:443
+      - aliasgroup1=https://${NC_DOMAIN}:443${NC_WEBROOT}
       - extra_params=--o:ssl.enable=false --o:ssl.termination=true --o:logging.level=warning --o:home_mode.enable=true ${COLLABORA_SECCOMP_POLICY} --o:remote_font_config.url=https://${NC_DOMAIN}/apps/richdocuments/settings/fonts.json
       - dictionaries=${COLLABORA_DICTIONARIES}
       - TZ=${TIMEZONE}
@@ -133,6 +135,7 @@ services:
       - ${TALK_PORT}:${TALK_PORT}/udp
     environment:
       - NC_DOMAIN=${NC_DOMAIN}
+      - NC_WEBROOT=${NC_WEBROOT}
       - TURN_SECRET=${TURN_SECRET}
       - SIGNALING_SECRET=${SIGNALING_SECRET}
       - JANUS_API_KEY=${JANUS_API_KEY}

--- a/manual-install/update-yaml.sh
+++ b/manual-install/update-yaml.sh
@@ -76,6 +76,7 @@ sed -i 's|TALK_PORT=|TALK_PORT=3478          # This allows to adjust the port th
 sed -i 's|AIO_TOKEN=|AIO_TOKEN=123456          # Has no function but needs to be set!|' sample.conf
 sed -i 's|AIO_URL=|AIO_URL=localhost          # Has no function but needs to be set!|' sample.conf
 sed -i 's|NC_DOMAIN=|NC_DOMAIN=yourdomain.com          # TODO! Needs to be changed to the domain that you want to use for Nextcloud.|' sample.conf
+sed -i 's|NC_WEBROOT=|NC_WEBROOT=/          # This allows to change the path in the url of nextcloud.|' sample.conf
 sed -i 's|NEXTCLOUD_PASSWORD=|NEXTCLOUD_PASSWORD=          # TODO! This is the password of the initially created Nextcloud admin with username "admin".|' sample.conf
 sed -i 's|TIMEZONE=|TIMEZONE=Europe/Berlin          # TODO! This is the timezone that your containers will use.|' sample.conf
 sed -i 's|COLLABORA_SECCOMP_POLICY=|COLLABORA_SECCOMP_POLICY=--o:security.seccomp=true          # Changing the value to false allows to disable the seccomp feature of the Collabora container.|' sample.conf

--- a/php/containers.json
+++ b/php/containers.json
@@ -20,6 +20,7 @@
       "internal_port": "%APACHE_PORT%",
       "environment": [
         "NC_DOMAIN=%NC_DOMAIN%",
+        "NC_WEBROOT=%NC_WEBROOT%",
         "NEXTCLOUD_HOST=nextcloud-aio-nextcloud",
         "COLLABORA_HOST=nextcloud-aio-collabora",
         "TALK_HOST=nextcloud-aio-talk",
@@ -123,6 +124,7 @@
         "REDIS_HOST_PASSWORD=%REDIS_PASSWORD%",
         "AIO_TOKEN=%AIO_TOKEN%",
         "NC_DOMAIN=%NC_DOMAIN%",
+        "NC_WEBROOT=%NC_WEBROOT%",
         "ADMIN_USER=admin",
         "ADMIN_PASSWORD=%NEXTCLOUD_PASSWORD%",
         "NEXTCLOUD_DATA_DIR=/mnt/ncdata",
@@ -188,7 +190,7 @@
       "image": "nextcloud/aio-collabora",
       "internal_port": "9980",
       "environment": [
-        "aliasgroup1=https://%NC_DOMAIN%:443",
+        "aliasgroup1=https://%NC_DOMAIN%:443%NC_WEBROOT%",
         "extra_params=--o:ssl.enable=false --o:ssl.termination=true --o:logging.level=warning --o:home_mode.enable=true %COLLABORA_SECCOMP_POLICY% --o:remote_font_config.url=https://%NC_DOMAIN%/apps/richdocuments/settings/fonts.json",
         "dictionaries=%COLLABORA_DICTIONARIES%",
         "TZ=%TIMEZONE%"
@@ -221,6 +223,7 @@
       "internal_port": "%TALK_PORT%",
       "environment": [
         "NC_DOMAIN=%NC_DOMAIN%",
+        "NC_WEBROOT=%NC_WEBROOT%",
         "TURN_SECRET=%TURN_SECRET%",
         "SIGNALING_SECRET=%SIGNALING_SECRET%",
         "JANUS_API_KEY=%JANUS_API_KEY%",

--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -252,6 +252,10 @@ class DockerActionManager
 
                 if($out[1] === 'NC_DOMAIN') {
                     $replacements[1] = $this->configurationManager->GetDomain();
+                } elseif ($out[1] === 'NC_DOMAIN') {
+                    $replacements[1] = '/';
+                } elseif ($out[1] === 'BORGBACKUP_MODE') {
+                    $replacements[1] = $this->configurationManager->GetBackupMode();
                 } elseif ($out[1] === 'AIO_TOKEN') {
                     $replacements[1] = $this->configurationManager->GetToken();
                 } elseif ($out[1] === 'BORGBACKUP_MODE') {

--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -252,10 +252,8 @@ class DockerActionManager
 
                 if($out[1] === 'NC_DOMAIN') {
                     $replacements[1] = $this->configurationManager->GetDomain();
-                } elseif ($out[1] === 'NC_DOMAIN') {
+                } elseif ($out[1] === 'NC_WEBROOT') {
                     $replacements[1] = '/';
-                } elseif ($out[1] === 'BORGBACKUP_MODE') {
-                    $replacements[1] = $this->configurationManager->GetBackupMode();
                 } elseif ($out[1] === 'AIO_TOKEN') {
                     $replacements[1] = $this->configurationManager->GetToken();
                 } elseif ($out[1] === 'BORGBACKUP_MODE') {


### PR DESCRIPTION
`NC_WEBROOT` values can be empty string, '/' (default), or any path like '/nextcloud'.

Required docker entrypoint scripts build+export an additional variable `NC_WEBROOT_P`, which is added directly after particular `host:port` combinations ('/' is converted to '' so `http://$host:$post$NC_WEBROOT_P/push` does not become `http://host:port//push`)

`NC_WEBROOT` is added to all possible paths of nextcloud, push, talk and onlyoffice but not collabora as there is no reasonable way to update their paths.

For mastercontainer/php configuration there is currently only the default value '/', but for manual-install this PR can be used directly.