### PR TITLE
Fix the middleware name in the Traefik doc

### DIFF
--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -362,7 +362,7 @@ Of course you need to modify `<your-nc-domain>` to the domain on which you want 
             entryPoints = ["https"]
             rule = "Host(<your-nc-domain>)"
             service = "nc-svc"
-            middlewares = ["chain-no-auth"]
+            middlewares = ["chain-nc"]
             [http.routers.nc-rtr.tls]
                 certresolver = "le"
 


### PR DESCRIPTION
The naming of the chain middleware in the Traefik example is inconsistent.