### PR TITLE
redis: add hint to wiki if overcommit disabled

### DIFF
--- a/Containers/redis/start.sh
+++ b/Containers/redis/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Show wiki if vm.overcommit is disabled
-if [[ $(sysctl -n vm.overcommit_memory)  != "1" ]]; then
+if [ "$(sysctl -n vm.overcommit_memory)" != "1" ]; then
     echo Memory overcommit is disabled but necessary for safe operation
     echo See https://github.com/nextcloud/all-in-one/discussions/1731 how to enable overcommit
 fi

--- a/Containers/redis/start.sh
+++ b/Containers/redis/start.sh
@@ -3,7 +3,7 @@
 # Show wiki if vm.overcommit is disabled
 if [ "$(sysctl -n vm.overcommit_memory)" != "1" ]; then
     echo "Memory overcommit is disabled but necessary for safe operation"
-    echo See https://github.com/nextcloud/all-in-one/discussions/1731 how to enable overcommit
+    echo "See https://github.com/nextcloud/all-in-one/discussions/1731 how to enable overcommit"
 fi
 
 # Run redis with a password if provided

--- a/Containers/redis/start.sh
+++ b/Containers/redis/start.sh
@@ -2,7 +2,7 @@
 
 # Show wiki if vm.overcommit is disabled
 if [ "$(sysctl -n vm.overcommit_memory)" != "1" ]; then
-    echo Memory overcommit is disabled but necessary for safe operation
+    echo "Memory overcommit is disabled but necessary for safe operation"
     echo See https://github.com/nextcloud/all-in-one/discussions/1731 how to enable overcommit
 fi
 

--- a/Containers/redis/start.sh
+++ b/Containers/redis/start.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Show wiki if vm.overcommit is disabled
+if [[ $(sysctl -n vm.overcommit_memory)  != "1" ]]; then
+    echo Memory overcommit is disabled but necessary for safe operation
+    echo See https://github.com/nextcloud/all-in-one/discussions/1731 how to enable overcommit
+fi
+
 # Run redis with a password if provided
 if [ -n "$REDIS_HOST_PASSWORD" ]; then
     exec redis-server --requirepass "$REDIS_HOST_PASSWORD"


### PR DESCRIPTION
You may see a warning by redis like `WARNING Memory overcommit must be enabled! Without it, a background save or replication may fail under low memory condition.`

In this case you have to enable vm.overcommit on your host machine (cannot be done by docker/redis), so this PR links to a discussion with commands and background information if vm.overcommit is disabled.