### PR TITLE
Fix the Traefik example

### DIFF
--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -383,7 +383,8 @@ Of course you need to modify `<your-nc-domain>` to the domain on which you want 
         [http.middlewares.nc-middlewares-secure-headers.headers]
             hostsProxyHeaders = ["X-Forwarded-Host"]
             referrerPolicy = "same-origin"
-            X-Robots-Tag = "none"
+            [http.middlewares.nc-middlewares-secure-headers.headers.customResponseHeaders]
+                X-Robots-Tag = "none"
     
     [http.middlewares.https-redirect.redirectscheme]
         scheme = "https"

--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -382,9 +382,11 @@ Of course you need to modify `<your-nc-domain>` to the domain on which you want 
     [http.middlewares.nc-middlewares-secure-headers]
         [http.middlewares.nc-middlewares-secure-headers.headers]
             hostsProxyHeaders = ["X-Forwarded-Host"]
-            sslRedirect = true
             referrerPolicy = "same-origin"
             X-Robots-Tag = "none"
+    
+    [http.middlewares.https-redirect.redirectscheme]
+        scheme = "https"
     ```
 
 3. Add to the bottom of the `middleware-chains.toml` file in the Traefik rules folder the following content:
@@ -392,7 +394,7 @@ Of course you need to modify `<your-nc-domain>` to the domain on which you want 
     ```toml
     [http.middlewares.chain-nc]
         [http.middlewares.chain-nc.chain]
-            middlewares = [ "nc-middlewares-secure-headers"]
+            middlewares = [ "https-redirect", "nc-middlewares-secure-headers"]
     ```
 
 ---


### PR DESCRIPTION
The Traefik example partly used deprecated properties, partly was incorrect. This MR aims to provide a working configuration.