### PR TITLE
Rewrite Traefik examples using YAML

### DIFF
--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -355,6 +355,8 @@ Of course you need to modify `<your-nc-domain>` to the domain on which you want 
 <summary>click here to expand</summary>
 
 **Disclaimer:** It might be possible that the config below is not working 100% correctly, yet. Improvements to it are very welcome!
+    
+The examples below define the dynamic configuration in YAML files. If you rather prefer TOML, use a YAML to TOML converter. 
 
 1. Add a `nextcloud.yml` to the Treafik rules folder with the following content
 

--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -370,6 +370,7 @@ Of course you need to modify `<your-nc-domain>` to the domain on which you want 
                     - nextcloud-chain
                 tls:
                     certresolver: "le"
+
         services:
             nextcloud:
                 loadBalancer:


### PR DESCRIPTION
Since [all examples](https://doc.traefik.io/traefik/providers/file/) are shown as YAML by default on the Traefik documentation page and I personally find YAML way more readable than TOML, I propose to rewrite our examples using YAML. 

Note that I used the oppurtunity to use more descriptive and sometimes compacter names.