### PR TITLE
change dind image to omit the alpine version

### DIFF
--- a/Containers/mastercontainer/Dockerfile
+++ b/Containers/mastercontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Docker CLI is a requirement
-FROM docker:20.10.21-dind-alpine3.16 as dind
+FROM docker:20.10.22-dind as dind
 
 # Caddy is a requirement
 FROM caddy:2.6.2-alpine as caddy


### PR DESCRIPTION
Reason: the image is by default alpine based. So by ommiting that we make sure that we get dependabot updates.

Signed-off-by: Simon L <szaimen@e.mail.de>