### PR TITLE
increase H2WindowSize limit (Reverse Proxy documentation)

### DIFF
--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -56,7 +56,7 @@ Add this as a new Apache site config:
     Protocols h2 h2c http/1.1
     
     # Solves slow upload speeds caused by http2
-    H2WindowSize 1048576
+    H2WindowSize 5242880
 
     # SSL
     SSLEngine on
@@ -258,9 +258,6 @@ server {
 
     listen 443 ssl http2;
     listen [::]:443 ssl http2; # comment to disable IPv6
-    
-    # Solves slow upload speeds caused by http2
-    http2_body_preread_size 1048576;
 
     server_name <your-nc-domain>;
 
@@ -273,6 +270,8 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_read_timeout 86400s;
         client_max_body_size 0;
+        # Solves slow upload speeds caused by http2
+        client_body_buffer_size 512k;
 
         # Websocket
         proxy_http_version 1.1;

--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -258,6 +258,9 @@ server {
 
     listen 443 ssl http2;
     listen [::]:443 ssl http2; # comment to disable IPv6
+    
+    # Solves slow upload speeds caused by http2
+    http2_body_preread_size 1048576;
 
     server_name <your-nc-domain>;
 
@@ -270,8 +273,6 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_read_timeout 86400s;
         client_max_body_size 0;
-        # Solves slow upload speeds caused by http2
-        client_body_buffer_size 512k;
 
         # Websocket
         proxy_http_version 1.1;


### PR DESCRIPTION
After recent tests, I found out that 512 KB is a more performant limit for the standard 10 GB upload limit.
With the 128 KB limit, the upload speed dropped from 6 MB/s to 4 MB/s after 1 GB was uploaded.
Now it stays between 5,5 MB/s and 6 MB/s for the entire upload.

Signed-off-by: -Denux <83671398+DenuxPlays@users.noreply.github.com>