### PR TITLE
imaginary - allow big images by default

### DIFF
--- a/Containers/imaginary/Dockerfile
+++ b/Containers/imaginary/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex; \
     rm -rf /var/lib/apt/lists/*
 USER nobody
 
-ENTRYPOINT ["/usr/local/bin/imaginary", "-return-size"]
+ENTRYPOINT ["/usr/local/bin/imaginary", "-return-size", "-max-allowed-resolution", "222.2"]
 
 HEALTHCHECK CMD nc -z localhost 9000 || exit 1
 LABEL com.centurylinklabs.watchtower.monitor-only="true"


### PR DESCRIPTION
Reason: the image size is already limited in Nextcloud. So no need to limit it additionally in imaginary.

Close https://github.com/nextcloud/all-in-one/discussions/1861

Signed-off-by: Simon L <szaimen@e.mail.de>