### PR TITLE
fix(helm): yes/true checks in all templates

### DIFF
--- a/helm-chart/templates/nextcloud-aio-clamav-deployment.yaml
+++ b/helm-chart/templates/nextcloud-aio-clamav-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.CLAMAV_ENABLED "yes" }}
+{{- if eq .Values.CLAMAV_ENABLED true }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm-chart/templates/nextcloud-aio-collabora-deployment.yaml
+++ b/helm-chart/templates/nextcloud-aio-collabora-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.COLLABORA_ENABLED "yes" }}
+{{- if eq .Values.COLLABORA_ENABLED true }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm-chart/templates/nextcloud-aio-fulltextsearch-deployment.yaml
+++ b/helm-chart/templates/nextcloud-aio-fulltextsearch-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.FULLTEXTSEARCH_ENABLED "yes" }}
+{{- if eq .Values.FULLTEXTSEARCH_ENABLED true }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm-chart/templates/nextcloud-aio-imaginary-deployment.yaml
+++ b/helm-chart/templates/nextcloud-aio-imaginary-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.IMAGINARY_ENABLED "yes" }}
+{{- if eq .Values.IMAGINARY_ENABLED true }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm-chart/templates/nextcloud-aio-onlyoffice-deployment.yaml
+++ b/helm-chart/templates/nextcloud-aio-onlyoffice-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.ONLYOFFICE_ENABLED "yes" }}
+{{- if eq .Values.ONLYOFFICE_ENABLED true }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm-chart/templates/nextcloud-aio-talk-deployment.yaml
+++ b/helm-chart/templates/nextcloud-aio-talk-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.TALK_ENABLED "yes" }}
+{{- if eq .Values.TALK_ENABLED true }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm-chart/templates/nextcloud-aio-talk-service.yaml
+++ b/helm-chart/templates/nextcloud-aio-talk-service.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.TALK_ENABLED "yes" }}
+{{- if eq .Values.TALK_ENABLED true }}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
This is kind of a footgun of YAML. YAML parses yes/true/no/false to booleans. It isn't possible to compare a boolean to a string in a template and thus helm fails on install.

Another option would be to quote all values to force them to be strings (but that might confuse admins), e.g.
```yaml
TALK_ENABLED: "yes"
```