### PR TITLE
connect containers only to custom network

### DIFF
--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -372,6 +372,7 @@ class DockerActionManager
                 $portWithProtocol = $value->port . '/' . $value->protocol;
                 $exposedPorts[$portWithProtocol] = null;
             }
+            $requestBody['HostConfig']['NetworkMode'] = 'nextcloud-aio';
         } else {
             $requestBody['HostConfig']['NetworkMode'] = 'host';
         }
@@ -622,11 +623,11 @@ class DockerActionManager
         }
     }
 
-    public function DisconnectContainerFromNetwork(Container $container) : void
+    private function DisconnectContainerFromBridgeNetwork(string $id) : void
     {
 
         $url = $this->BuildApiUrl(
-            sprintf('networks/%s/disconnect', 'nextcloud-aio')
+            sprintf('networks/%s/disconnect', 'bridge')
         );
 
         try {
@@ -635,12 +636,11 @@ class DockerActionManager
                 $url,
                 [
                     'json' => [
-                        'container' => $container->GetIdentifier(),
+                        'container' => $id,
                     ],
                 ]
             );
         } catch (RequestException $e) {
-            error_log('Could not disconnect container from network ' . $e->getMessage());
         }
     }
 
@@ -699,6 +699,7 @@ class DockerActionManager
     public function ConnectMasterContainerToNetwork() : void
     {
         $this->ConnectContainerIdToNetwork('nextcloud-aio-mastercontainer', '');
+        $this->DisconnectContainerFromBridgeNetwork('nextcloud-aio-mastercontainer');
     }
 
     public function ConnectContainerToNetwork(Container $container) : void


### PR DESCRIPTION
The problem was that when creating containers without specifiying the custom network directly, they will get automatically addded to the default bridge network.