### PR TITLE
docker-aio-config should not be a volume by default

### DIFF
--- a/Containers/mastercontainer/Dockerfile
+++ b/Containers/mastercontainer/Dockerfile
@@ -18,10 +18,6 @@ EXPOSE 80
 EXPOSE 8080
 EXPOSE 8443
 
-RUN mkdir -p /mnt/docker-aio-config/;
-
-VOLUME /mnt/docker-aio-config/
-
 RUN mkdir -p /var/www/docker-aio;
 
 WORKDIR /var/www/docker-aio


### PR DESCRIPTION
Prevent something like https://www.reddit.com/r/NextCloud/comments/113mfi1/comment/j8vrzx6/?utm_source=share&utm_medium=web2x&context=3 from happening in the future since this check comes into play then: https://github.com/nextcloud/all-in-one/blob/bc100b9fd83d6e5603fc1c21bfc8a875c9e38d29/Containers/mastercontainer/start.sh#L21-L23