### PR TITLE
Add the directive ProxyPassReverse

### DIFF
--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -48,7 +48,10 @@ Add this as a new Apache site config:
     RewriteEngine On
     ProxyPreserveHost On
     AllowEncodedSlashes NoDecode
+    
     ProxyPass / http://localhost:11000/ nocanon
+    ProxyPassReverse / http://localhost:11000/
+    
     RewriteCond %{HTTP:Upgrade} websocket [NC]
     RewriteCond %{HTTP:Connection} upgrade [NC]
     RewriteCond %{THE_REQUEST} "^[a-zA-Z]+ /(.*) HTTP/\d+(\.\d+)?$"


### PR DESCRIPTION
According to the official documentation of Apache the directive ProxyPassReverse should be added when Apache is being used as a reverse proxy. I have tested it and Nexctloud AIO seems to work just fine.

From the documentation:
"This directive lets Apache adjust the URL in the Location, Content-Location and URI headers on HTTP redirect responses. This is essential when Apache is used as a reverse proxy (or gateway) to avoid bypassing the reverse proxy because of HTTP redirects on the backend servers which stay behind the reverse proxy."

https://httpd.apache.org/docs/2.2/mod/mod_proxy.html#ProxyPassReverse