### PR TITLE
remove tzdata from mastercontainer

### DIFF
--- a/Containers/mastercontainer/Dockerfile
+++ b/Containers/mastercontainer/Dockerfile
@@ -27,7 +27,6 @@ RUN set -ex; \
         util-linux-misc \
         ca-certificates \
         wget \
-        tzdata \
         bash \
         apache2 \
         apache2-proxy \


### PR DESCRIPTION
We don't support switching the timezone for the mastercontainer so we can remove the package