### PR TITLE
add default path for borg compact

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -326,7 +326,7 @@ sudo borg delete --stats --progress "/mnt/backup/borg::20220223_174237-nextcloud
 # If borg 1.2.0 or higher is installed, you then need to run borg compact in order to clean up the freed space
 sudo borg --version
 # If version number of the command above is higher than 1.2.0 you need to run the command below:
-sudo borg compact "/mnt/backup/"
+sudo borg compact "/mnt/backup/borg"
 
 ```
 


### PR DESCRIPTION
all examples up until the compact section work under the assumption that you are using the default backup path "/mnt/backup/borg" so path for compact should be the same 💙