### PR TITLE
Missing brace in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -240,7 +240,7 @@ Here is how to reset the AIO instance properly:
 1. Check which volumes are dangling with `sudo docker volume ls --filter "dangling=true"`
 1. Now remove all these dangling volumes: `sudo docker volume prune` (on Windows you might need to remove some volumes afterwards manually with `docker volume rm nextcloud_aio_backupdir`, `docker volume rm nextcloud_aio_nextcloud_datadir`). 
 1. If you've configured `NEXTCLOUD_DATADIR` to a path on your host instead of the default volume, you need to clean that up as well. (E.g. by simply deleting the directory).
-1. Make sure that no volumes are remaining with `sudo docker volume ls --format {{.Name}`. If no `nextcloud-aio` volumes are listed, you can proceed with the steps below. If there should be some, you will need to stop them with `sudo docker volume rm <volume_name>` until no one is listed anymore.
+1. Make sure that no volumes are remaining with `sudo docker volume ls --format {{.Name}}`. If no `nextcloud-aio` volumes are listed, you can proceed with the steps below. If there should be some, you will need to stop them with `sudo docker volume rm <volume_name>` until no one is listed anymore.
 1. Optional: You can remove all docker images with `sudo docker image prune -a`.
 1. And you are done! Now feel free to start over with the recommended docker run command!
 


### PR DESCRIPTION
`sudo docker volume ls --format {{.Name}` command is invalid and gives the error `template parsing error: template: :1: unexpected "}" in operand`

This change provides a fix by adding the missing brace.