### PR TITLE
Proxy instructions for NodeJS/express

### DIFF
--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -358,6 +358,8 @@ Of course you need to modify `<your-nc-domain>` to the domain on which you want 
 
 <summary>click here to expand</summary>
 
+**Disclaimer:** It might be possible that the config below is not working 100% correctly, yet. Improvements to it are very welcome!
+
 For Node.js, we will use the npm package `http-proxy`. WebSockets must be handled separately.
 
 This example only uses `http`, but if your Express server already uses a `https` server, then follow the same instructions for `https`.
@@ -422,8 +424,7 @@ myNextcloudApp.use((req, res) => {
 	proxy.web(req, res, {}, onProxyError);
 });
 
-vhost.use(vhostFunc('nextcloud.example.com', myNextcloudApp));
-vhost.use(vhostFunc('www.example.com', myOtherApp));
+vhost.use(vhostFunc('<your-nextcloud-domain>', myNextcloudApp));
 
 const httpServer = http.createServer(app);
 httpServer.listen('80');
@@ -433,6 +434,10 @@ httpServer.on('upgrade', (req, socket, head) => {
 	proxy.ws(req, socket, head, {}, onProxyError);
 });
 ```
+
+Of course you need to modify `<your-nc-domain>` to the domain on which you want to run Nextcloud. Also make sure to adjust the port 11000 to match the chosen `APACHE_PORT`. 
+**Please note:** The above configuration will only work if your reverse proxy is running directly on the host that is running the docker daemon. If the reverse proxy is running in a docker container, you can use the `--network host` option (or `network_mode: host` for docker-compose) when starting the reverse proxy container in order to connect the reverse proxy container to the host network. ***If that is not an option or not possible for you (like e.g. on Windows or if the reverse proxy is running on a different host), you can alternatively instead of `localhost` use the private ip-address of the host that is running the docker daemon. If you are not sure how to retrieve that, you can run: `ip a | grep "scope global" | head -1 | awk '{print $2}' | sed 's|/.*||'`. If the command returns a public ip-address, use `ip a | grep "scope global" | grep docker0 | awk '{print $2}' | sed 's|/.*||'` instead (the commands only work on Linux)***
+
 </details>
 
 ### Synology Reverse Proxy


### PR DESCRIPTION
Added instructions for how to proxy network requests for AIO when running a NodeJS server. I personally use CloudFlare's proxying, so it technically works just with the httpServer. The instructions are the same for those using httpsServer, and I believe that anyone who was knowledgeable enough to set up a nodejs server will be able to adapt the instructions to their specific use-case. 