### PR TITLE
run composer during install as non-root user 

### DIFF
--- a/Containers/mastercontainer/Dockerfile
+++ b/Containers/mastercontainer/Dockerfile
@@ -72,9 +72,10 @@ RUN set -e && \
     cd /var/www/docker-aio; \
     git clone https://github.com/nextcloud-releases/all-in-one.git --depth 1 .; \
     find ./ -not -path ./php -maxdepth 1 -mindepth 1 -delete; \
+    chown www-data:www-data -R /var/www/docker-aio; \
     cd php; \
-    composer install --no-dev; \
-    composer clearcache; \
+    sudo -u www-data composer install --no-dev; \
+    sudo -u www-data composer clearcache; \
     cd ..; \
     rm -f /usr/local/bin/composer; \
     chmod 770 -R ./; \


### PR DESCRIPTION
reason: recommended for security