### PR TITLE
revert disabling FTS if on Nc26

### DIFF
--- a/Containers/nextcloud/entrypoint.sh
+++ b/Containers/nextcloud/entrypoint.sh
@@ -631,12 +631,6 @@ if version_greater "$installed_version" "24.0.0.0"; then
     fi
 fi
 
-# Migration to ES8 is pending, thus disabling FTS for now.
-if [ "$INSTALL_LATEST_MAJOR" = yes ] || version_greater "$installed_version" "26.0.0.0"; then
-    export FULLTEXTSEARCH_ENABLED=no
-    echo "Fulltextsearch is not compatible with Nextcloud 26 and is getting disabled."
-fi
-
 # Fulltextsearch
 if [ "$FULLTEXTSEARCH_ENABLED" = 'yes' ]; then
     while ! nc -z "$FULLTEXTSEARCH_HOST" 9200; do


### PR DESCRIPTION
Apparently ES7 still works even with nc26 based on Maxence