### PR TITLE
Makes imaginary port configurable

### DIFF
--- a/Containers/imaginary/Dockerfile
+++ b/Containers/imaginary/Dockerfile
@@ -31,5 +31,5 @@ USER nobody
 ENV MALLOC_ARENA_MAX=2
 ENTRYPOINT ["imaginary", "-return-size", "-max-allowed-resolution", "222.2"]
 
-HEALTHCHECK CMD nc -z localhost $PORT || exit 1
+HEALTHCHECK CMD nc -z localhost "$PORT" || exit 1
 LABEL com.centurylinklabs.watchtower.monitor-only="true"

--- a/Containers/imaginary/Dockerfile
+++ b/Containers/imaginary/Dockerfile
@@ -23,11 +23,13 @@ RUN set -ex; \
 
 COPY --from=go /go/bin/imaginary /usr/local/bin/imaginary
 
+ENV PORT 9000
+
 USER nobody
 
 # https://github.com/h2non/imaginary#memory-issues
 ENV MALLOC_ARENA_MAX=2
-ENTRYPOINT ["imaginary", "-p", "9000", "-return-size", "-max-allowed-resolution", "222.2"]
+ENTRYPOINT ["imaginary", "-return-size", "-max-allowed-resolution", "222.2"]
 
-HEALTHCHECK CMD nc -z localhost 9000 || exit 1
+HEALTHCHECK CMD nc -z localhost $PORT || exit 1
 LABEL com.centurylinklabs.watchtower.monitor-only="true"


### PR DESCRIPTION
With commit https://github.com/nextcloud/all-in-one/commit/6fe6d7e0b4da44a57b1f1c1226b40fb712b50a22 the imaginary image lost the possibility of manually configuring the port imaginary listens to.

The original image, where this one was based on (https://github.com/h2non/imaginary/blob/master/Dockerfile), does support defining the port as ENV variable.

This PR introduces this capability again, also for AIO.

Why is it needed? In my case I am running some of the AIO containers in one Podman pod. Within a pod all containers share the same network namespace. Because php fpm and imaginary are using port 9000 by default, I welcomed the possibility of the imaginary image to change the default port.