### PR TITLE
Switch from mawk to built-in awk

### DIFF
--- a/Containers/nextcloud/Dockerfile
+++ b/Containers/nextcloud/Dockerfile
@@ -184,7 +184,6 @@ RUN set -ex; \
         git \
         postgresql-client \
         tzdata \
-        mawk \
         sudo \
         grep \
         nodejs \

--- a/Containers/nextcloud/entrypoint.sh
+++ b/Containers/nextcloud/entrypoint.sh
@@ -22,7 +22,7 @@ redis.session.lock_wait_time = 10000
 REDIS_CONF
 
 echo "Setting php max children..."
-MEMORY=$(mawk '/MemTotal/ {printf "%d", $2/1024}' /proc/meminfo)
+MEMORY=$(awk '/MemTotal/ {printf "%d", $2/1024}' /proc/meminfo)
 PHP_MAX_CHILDREN=$((MEMORY/50))
 if [ -n "$PHP_MAX_CHILDREN" ]; then
     sed -i "s/^pm.max_children =.*/pm.max_children = $PHP_MAX_CHILDREN/" /usr/local/etc/php-fpm.d/www.conf

--- a/Containers/postgresql/Dockerfile
+++ b/Containers/postgresql/Dockerfile
@@ -6,7 +6,7 @@ COPY --chmod=775 healthcheck.sh /healthcheck.sh
 COPY --chmod=775 init-user-db.sh /docker-entrypoint-initdb.d/init-user-db.sh
 
 RUN set -ex; \
-    apk add --no-cache bash openssl shadow grep mawk; \
+    apk add --no-cache bash openssl shadow grep; \
     \
 # We need to use the same gid and uid as on old installations
     deluser postgres; \

--- a/Containers/postgresql/start.sh
+++ b/Containers/postgresql/start.sh
@@ -147,7 +147,7 @@ if ! [ -f "$DATADIR/PG_VERSION" ] && ! [ -f "$DUMP_FILE" ]; then
 fi
 
 echo "Setting max connections..."
-MEMORY=$(mawk '/MemTotal/ {printf "%d", $2/1024}' /proc/meminfo)
+MEMORY=$(awk '/MemTotal/ {printf "%d", $2/1024}' /proc/meminfo)
 MAX_CONNECTIONS=$((MEMORY/50+3))
 if [ -n "$MAX_CONNECTIONS" ]; then
     sed -i "s|^max_connections =.*|max_connections = $MAX_CONNECTIONS|" "/var/lib/postgresql/data/postgresql.conf"


### PR DESCRIPTION
The built-in `awk` command yields the same results as the extra package `mawk`. The proposed pull request removes `mawk` as an extra dependency and adjusts the respective command to get the total amount of memory of the system.