### PR TITLE
adjust janus debug-level to 3 = warn

### DIFF
--- a/Containers/talk/supervisord.conf
+++ b/Containers/talk/supervisord.conf
@@ -27,7 +27,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
-command=janus --config=/etc/janus/janus.jcfg --disable-colors --log-stdout --full-trickle
+command=janus --config=/etc/janus/janus.jcfg --disable-colors --log-stdout --full-trickle --debug-level 3
 
 [program:signaling]
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
I checked: the others in the talk container do not have a loglevel.