### PR TITLE
mastercontainer - disable http3

### DIFF
--- a/Containers/mastercontainer/Caddyfile
+++ b/Containers/mastercontainer/Caddyfile
@@ -12,7 +12,7 @@
     }
 
     servers {
-        protocols h1 h2
+        protocols h1 h2 h2c
     }
 }
 

--- a/Containers/mastercontainer/Caddyfile
+++ b/Containers/mastercontainer/Caddyfile
@@ -10,6 +10,10 @@
     log {
         level ERROR
     }
+
+    servers {
+        protocols h1 h2
+    }
 }
 
 http://:80 {


### PR DESCRIPTION
Reason: http3 seems overkill for the AIO interface since it is server-side-rendered and should transfer only very few bytes.