### PR TITLE
small improvement to files_antivirus settings

### DIFF
--- a/Containers/nextcloud/entrypoint.sh
+++ b/Containers/nextcloud/entrypoint.sh
@@ -648,7 +648,7 @@ if [ "$CLAMAV_ENABLED" = 'yes' ]; then
         php /var/www/html/occ config:app:set files_antivirus av_port --value="3310"
         php /var/www/html/occ config:app:set files_antivirus av_host --value="$CLAMAV_HOST"
         php /var/www/html/occ config:app:set files_antivirus av_stream_max_length --value="104857600"
-        php /var/www/html/occ config:app:set files_antivirus av_max_file_size --value="-1"
+        php /var/www/html/occ config:app:set files_antivirus av_max_file_size --value="104857600"
         php /var/www/html/occ config:app:set files_antivirus av_infected_action --value="only_log"
     fi
 else


### PR DESCRIPTION
As notied in https://github.com/nextcloud/all-in-one/issues/2838#issuecomment-1600976726, it probably makes sense to match the configured limit from clamav.

Hopefully prevent something like https://github.com/nextcloud/all-in-one/issues/2838