### PR TITLE
add logging in case disk space is low and thus login might fail

### DIFF
--- a/php/src/Auth/AuthManager.php
+++ b/php/src/Auth/AuthManager.php
@@ -28,6 +28,12 @@ class AuthManager {
             $date = new DateTime();
             $dateTime = $date->getTimestamp();
             $_SESSION['date_time'] = $dateTime;
+
+            $df = disk_free_space(DataConst::GetSessionDirectory());
+            if ($df !== false && (int)$df < 10240) {
+                error_log(DataConst::GetSessionDirectory() . " has only less than 10KB free space. The login might not succeed because of that!");
+            }
+
             file_put_contents(DataConst::GetSessionDateFile(), (string)$dateTime);
         }
 


### PR DESCRIPTION
Make issues like https://help.nextcloud.com/t/nextcloud-aio-interface-not-accepting-admin-pass-phrase/164867 easier to debug