### PR TITLE
disable watchtower pulling for containers

### DIFF
--- a/Containers/apache/Dockerfile
+++ b/Containers/apache/Dockerfile
@@ -71,4 +71,4 @@ ENTRYPOINT ["/start.sh"]
 CMD ["/usr/bin/supervisord", "-c", "/supervisord.conf"]
 
 HEALTHCHECK CMD /healthcheck.sh
-LABEL com.centurylinklabs.watchtower.monitor-only="true"
+LABEL com.centurylinklabs.watchtower.enable="false"

--- a/Containers/borgbackup/Dockerfile
+++ b/Containers/borgbackup/Dockerfile
@@ -18,5 +18,5 @@ COPY --chmod=770 *.sh /
 ENTRYPOINT ["/start.sh"]
 USER root
 
-LABEL com.centurylinklabs.watchtower.monitor-only="true"
+LABEL com.centurylinklabs.watchtower.enable="false"
 ENV BORG_RETENTION_POLICY="--keep-within=7d --keep-weekly=4 --keep-monthly=6"

--- a/Containers/clamav/Dockerfile
+++ b/Containers/clamav/Dockerfile
@@ -15,4 +15,4 @@ VOLUME /var/lib/clamav
 
 USER clamav
 
-LABEL com.centurylinklabs.watchtower.monitor-only="true"
+LABEL com.centurylinklabs.watchtower.enable="false"

--- a/Containers/collabora/Dockerfile
+++ b/Containers/collabora/Dockerfile
@@ -16,4 +16,4 @@ RUN set -ex; \
 USER 100
 
 HEALTHCHECK CMD nc -z localhost 9980 || exit 1
-LABEL com.centurylinklabs.watchtower.monitor-only="true"
+LABEL com.centurylinklabs.watchtower.enable="false"

--- a/Containers/domaincheck/Dockerfile
+++ b/Containers/domaincheck/Dockerfile
@@ -14,4 +14,4 @@ USER www-data
 ENTRYPOINT ["/start.sh"]
 
 HEALTHCHECK CMD nc -z localhost $APACHE_PORT || exit 1
-LABEL com.centurylinklabs.watchtower.monitor-only="true"
+LABEL com.centurylinklabs.watchtower.enable="false"

--- a/Containers/fulltextsearch/Dockerfile
+++ b/Containers/fulltextsearch/Dockerfile
@@ -16,4 +16,4 @@ RUN set -ex; \
 USER 1000:0
 
 HEALTHCHECK CMD nc -z localhost 9200 || exit 1
-LABEL com.centurylinklabs.watchtower.monitor-only="true"
+LABEL com.centurylinklabs.watchtower.enable="false"

--- a/Containers/imaginary/Dockerfile
+++ b/Containers/imaginary/Dockerfile
@@ -35,4 +35,4 @@ ENV MALLOC_ARENA_MAX=2
 ENTRYPOINT ["imaginary", "-return-size", "-max-allowed-resolution", "222.2"]
 
 HEALTHCHECK CMD nc -z localhost "$PORT" || exit 1
-LABEL com.centurylinklabs.watchtower.monitor-only="true"
+LABEL com.centurylinklabs.watchtower.enable="false"

--- a/Containers/nextcloud/Dockerfile
+++ b/Containers/nextcloud/Dockerfile
@@ -223,4 +223,4 @@ ENTRYPOINT ["/start.sh"]
 CMD ["/usr/bin/supervisord", "-c", "/supervisord.conf"]
 
 HEALTHCHECK CMD sudo -E -u www-data bash /healthcheck.sh
-LABEL com.centurylinklabs.watchtower.monitor-only="true"
+LABEL com.centurylinklabs.watchtower.enable="false"

--- a/Containers/notify-push/Dockerfile
+++ b/Containers/notify-push/Dockerfile
@@ -18,4 +18,4 @@ USER 33
 ENTRYPOINT ["/start.sh"]
 
 HEALTHCHECK CMD nc -z localhost 7867 || exit 1
-LABEL com.centurylinklabs.watchtower.monitor-only="true"
+LABEL com.centurylinklabs.watchtower.enable="false"

--- a/Containers/onlyoffice/Dockerfile
+++ b/Containers/onlyoffice/Dockerfile
@@ -4,4 +4,4 @@ FROM onlyoffice/documentserver:7.4.0.1
 # USER root is probably used
 
 HEALTHCHECK CMD nc -z localhost 80 || exit 1
-LABEL com.centurylinklabs.watchtower.monitor-only="true"
+LABEL com.centurylinklabs.watchtower.enable="false"

--- a/Containers/postgresql/Dockerfile
+++ b/Containers/postgresql/Dockerfile
@@ -37,4 +37,4 @@ USER postgres
 ENTRYPOINT ["/start.sh"]
 
 HEALTHCHECK CMD /healthcheck.sh
-LABEL com.centurylinklabs.watchtower.monitor-only="true"
+LABEL com.centurylinklabs.watchtower.enable="false"

--- a/Containers/redis/Dockerfile
+++ b/Containers/redis/Dockerfile
@@ -13,4 +13,4 @@ USER redis
 ENTRYPOINT ["/start.sh"]
 
 HEALTHCHECK CMD redis-cli -a $REDIS_HOST_PASSWORD PING || exit 1
-LABEL com.centurylinklabs.watchtower.monitor-only="true"
+LABEL com.centurylinklabs.watchtower.enable="false"

--- a/Containers/talk-recording/Dockerfile
+++ b/Containers/talk-recording/Dockerfile
@@ -43,4 +43,4 @@ ENTRYPOINT ["/start.sh"]
 CMD ["python", "-m", "nextcloud.talk.recording", "--config", "/etc/recording.conf"]
 
 HEALTHCHECK CMD nc -z localhost 1234 || exit 1
-LABEL com.centurylinklabs.watchtower.monitor-only="true"
+LABEL com.centurylinklabs.watchtower.enable="false"

--- a/Containers/talk/Dockerfile
+++ b/Containers/talk/Dockerfile
@@ -71,4 +71,4 @@ ENTRYPOINT ["/start.sh"]
 CMD ["supervisord", "-c", "/supervisord.conf"]
 
 HEALTHCHECK CMD (nc -z localhost 8081 && nc -z localhost 8188 && nc -z localhost 4222 && nc -z localhost "$TALK_PORT" && nc -z "$NC_DOMAIN" "$TALK_PORT") || exit 1
-LABEL com.centurylinklabs.watchtower.monitor-only="true"
+LABEL com.centurylinklabs.watchtower.enable="false"

--- a/Containers/watchtower/Dockerfile
+++ b/Containers/watchtower/Dockerfile
@@ -11,4 +11,4 @@ COPY --chmod=775 start.sh /start.sh
 USER root
 
 ENTRYPOINT ["/start.sh"]
-LABEL com.centurylinklabs.watchtower.monitor-only="true"
+LABEL com.centurylinklabs.watchtower.enable="false"


### PR DESCRIPTION
Reason: apparently does monitor-only still pull the images but we don't want it to do even that.