### PR TITLE
revert adjustment of tempdirectory

### DIFF
--- a/Containers/nextcloud/entrypoint.sh
+++ b/Containers/nextcloud/entrypoint.sh
@@ -444,12 +444,14 @@ if [ -z "$OBJECTSTORE_S3_BUCKET" ] && [ -z "$OBJECTSTORE_SWIFT_URL" ]; then
         exit 1
     fi
 
-    # Configure tempdirectory
-    mkdir -p "$NEXTCLOUD_DATA_DIR/tmp/"
-    if ! grep -q upload_tmp_dir /usr/local/etc/php/conf.d/nextcloud.ini; then
-        echo "upload_tmp_dir = $NEXTCLOUD_DATA_DIR/tmp/" >> /usr/local/etc/php/conf.d/nextcloud.ini
+    # Delete formerly configured tempdirectory as the default is usually faster (if the datadir is on a HDD or network FS)
+    if [ "$(php /var/www/html/occ config:system:get tempdirectory)" = "$NEXTCLOUD_DATA_DIR/tmp/" ]; then
+        php /var/www/html/occ config:system:delete tempdirectory
+        if [ -d "$NEXTCLOUD_DATA_DIR/tmp/" ]; then
+            rm -r "$NEXTCLOUD_DATA_DIR/tmp/"
+        fi
     fi
-    php /var/www/html/occ config:system:set tempdirectory --value="$NEXTCLOUD_DATA_DIR/tmp/"
+
 fi
 
 # Perform fingerprint update if instance was restored


### PR DESCRIPTION
Supercedes https://github.com/nextcloud/all-in-one/pull/2856

Motivation: we introduced this tempdir setting initially in order to make big file uploads more reliable. However later on we found out that inside containers usually no tmpfs is used by default which would come with limitations in regard to the max size. Additionally, setting this to the datadir comes with drawbacks like performance problems and symlink problems. So better to just revert this setting and use the default.