### PR TITLE
documentation: misspelling

### DIFF
--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -642,7 +642,7 @@ Simply translate the docker run command into a docker-compose file. You can have
 
 ## 3. Limit the access to the apache container
 
-Use this envorinmental variable during the initial startup of the mastercontainer to make the apache container only listen on localhost: `--env APACHE_IP_BINDING=127.0.0.1`. **Attention:** This is only recommended to be set if you use `localhost` in your reverse proxy config to connect to your AIO instance. If you use an ip-address instead of localhost, you should set it to `0.0.0.0`.
+Use this environment variable during the initial startup of the mastercontainer to make the apache container only listen on localhost: `--env APACHE_IP_BINDING=127.0.0.1`. **Attention:** This is only recommended to be set if you use `localhost` in your reverse proxy config to connect to your AIO instance. If you use an ip-address instead of localhost, you should set it to `0.0.0.0`.
 
 ## 4. Open the AIO interface.
 After starting AIO, you should be able to access the AIO Interface via `https://ip.address.of.the.host:8080`. Enter your domain that you've entered in the reverse proxy config and you should be done. Please do not forget to open/forward port `3478/TCP` and `3478/UDP` in your firewall/router for the Talk container!


### PR DESCRIPTION
# English error

## diff

```diff
- envorinmental
+ environment
```

## Command used to fix

```bash
sed -i \
's/envorinmental/environment/g' \
$(find . -type f)
```