### PR TITLE
Revert "make collabora container read-only"

### DIFF
--- a/Containers/collabora/Dockerfile
+++ b/Containers/collabora/Dockerfile
@@ -11,10 +11,7 @@ RUN set -ex; \
         tzdata \
         netcat-openbsd \
     ; \
-    rm -rf /var/lib/apt/lists/*; \
-    mkdir -p /opt/cool/child-roots; \
-    chmod 777 -R /opt/cool/child-roots; \
-    chmod -R 777 /etc/coolwsd/
+    rm -rf /var/lib/apt/lists/*;
 
 USER 100
 

--- a/php/containers.json
+++ b/php/containers.json
@@ -302,11 +302,6 @@
       ],
       "networks": [
         "nextcloud-aio"
-      ],
-      "read_only": true,
-      "tmpfs": [
-        "/opt/cool/child-roots",
-        "/etc/coolwsd"
       ]
     },
     {


### PR DESCRIPTION
This reverts https://github.com/nextcloud/all-in-one/pull/2872

Reason: it is not possible to make it read only without huge effort