### PR TITLE
mastercontainer - run supervisord directly and not as cmd option

### DIFF
--- a/Containers/mastercontainer/Dockerfile
+++ b/Containers/mastercontainer/Dockerfile
@@ -121,6 +121,5 @@ COPY mastercontainer.conf /etc/apache2/sites-available/mastercontainer.conf
 USER root
 
 ENTRYPOINT ["/start.sh"]
-CMD ["/usr/bin/supervisord", "-c", "/supervisord.conf"]
 
 HEALTHCHECK CMD /healthcheck.sh

--- a/Containers/mastercontainer/start.sh
+++ b/Containers/mastercontainer/start.sh
@@ -318,5 +318,3 @@ chmod 777 /root
 
 # Start supervisord
 /usr/bin/supervisord -c /supervisord.conf
-
-exec "$@"

--- a/Containers/mastercontainer/start.sh
+++ b/Containers/mastercontainer/start.sh
@@ -26,6 +26,12 @@ if [ "$EUID" != "0" ]; then
     exit 1
 fi
 
+# Check that the CMD is not overwritten nor set
+if [ "$*" != "" ]; then
+    print_red "Docker run command for AIO is incorrect as a CMD option was given which is not expected."
+    exit 1
+fi
+
 # Check if socket is available and readable
 if ! [ -a "/var/run/docker.sock" ]; then
     print_red "Docker socket is not available. Cannot continue."
@@ -309,5 +315,8 @@ caddy fmt --overwrite /Caddyfile
 
 # Fix caddy log 
 chmod 777 /root
+
+# Start supervisord
+/usr/bin/supervisord -c /supervisord.conf
 
 exec "$@"


### PR DESCRIPTION
Close https://github.com/nextcloud/all-in-one/discussions/3014