### PR TITLE
postgresql - adjust calculation of max database connections

### DIFF
--- a/Containers/postgresql/start.sh
+++ b/Containers/postgresql/start.sh
@@ -150,7 +150,10 @@ fi
 if [ -f "/var/lib/postgresql/data/postgresql.conf" ]; then
     echo "Setting max connections..."
     MEMORY=$(awk '/MemTotal/ {printf "%d", $2/1024}' /proc/meminfo)
-    MAX_CONNECTIONS=$((MEMORY/50+3))
+    # Double amount of connections compared to max php-fpm children - so divided by 25 and not 50
+    MAX_CONNECTIONS=$((MEMORY/25))
+    # Subtract 3 connections, reserved for master
+    MAX_CONNECTIONS=$((MAX_CONNECTIONS-3))
     if [ -n "$MAX_CONNECTIONS" ]; then
         sed -i "s|^max_connections =.*|max_connections = $MAX_CONNECTIONS|" "/var/lib/postgresql/data/postgresql.conf"
     fi


### PR DESCRIPTION
Fix https://github.com/nextcloud/all-in-one/discussions/2839

- [ ] TODO: alternatively check https://github.com/nextcloud/all-in-one/discussions/2839#discussioncomment-6523156 (should if successful also be adjusted in https://docs.nextcloud.com/server/latest/admin_manual/configuration_database/linux_database_configuration.html?highlight=dbdriveroptions)

<details>
<summary></summary>

Just to leave it somewhere: https://www.cybertec-postgresql.com/en/tuning-max_connections-in-postgresql/

</details>