### PR TITLE
remove export for HPB domain

### DIFF
--- a/Containers/talk-recording/start.sh
+++ b/Containers/talk-recording/start.sh
@@ -12,10 +12,6 @@ elif [ -z "$INTERNAL_SECRET" ]; then
     exit 1
 fi
 
-if [ -z "$HPB_DOMAIN" ]; then
-    export HPB_DOMAIN="$NC_DOMAIN"
-fi
-
 cat << RECORDING_CONF > "/conf/recording.conf"
 [logs]
 # 30 means Warning

--- a/Containers/talk-recording/start.sh
+++ b/Containers/talk-recording/start.sh
@@ -16,8 +16,6 @@ if [ -z "$HPB_DOMAIN" ]; then
     export HPB_DOMAIN
 fi
 
-
-
 cat << RECORDING_CONF > "/conf/recording.conf"
 [logs]
 # 30 means Warning

--- a/Containers/talk-recording/start.sh
+++ b/Containers/talk-recording/start.sh
@@ -12,6 +12,12 @@ elif [ -z "$INTERNAL_SECRET" ]; then
     exit 1
 fi
 
+if [ -z "$HPB_DOMAIN" ]; then
+    export HPB_DOMAIN
+fi
+
+
+
 cat << RECORDING_CONF > "/conf/recording.conf"
 [logs]
 # 30 means Warning


### PR DESCRIPTION
It's not needed to export the `HPB_DOMAIN` as that would mean it's the same as `NC_DOMAIN`, which is not the case if `HPB_DOMAIN` is used. 

Was a bit to quick when reviewing, sorry.

In the VM we use both domains, as they are seperate: https://github.com/nextcloud/vm/blob/master/apps/talk.sh#L536-L537