### PR TITLE
Update `depends_on:` of latest.yml

### DIFF
--- a/manual-install/latest.yml
+++ b/manual-install/latest.yml
@@ -1,11 +1,21 @@
 services:
   nextcloud-aio-apache:
     depends_on:
-      - nextcloud-aio-onlyoffice
-      - nextcloud-aio-collabora
-      - nextcloud-aio-talk
-      - nextcloud-aio-nextcloud
-      - nextcloud-aio-notify-push
+      nextcloud-aio-onlyoffice:
+        condition: service_started
+        required: false
+      nextcloud-aio-collabora:
+        condition: service_started
+        required: false
+      nextcloud-aio-talk:
+        condition: service_started
+        required: false
+      nextcloud-aio-nextcloud:
+        condition: service_started
+        required: false
+      nextcloud-aio-notify-push:
+        condition: service_started
+        required: false
     image: nextcloud/aio-apache:latest
     ports:
       - ${APACHE_IP_BINDING}:${APACHE_PORT}:${APACHE_PORT}/tcp
@@ -59,12 +69,24 @@ services:
 
   nextcloud-aio-nextcloud:
     depends_on:
-      - nextcloud-aio-database
-      - nextcloud-aio-redis
-      - nextcloud-aio-clamav
-      - nextcloud-aio-fulltextsearch
-      - nextcloud-aio-talk-recording
-      - nextcloud-aio-imaginary
+      nextcloud-aio-database:
+        condition: service_started
+        required: false
+      nextcloud-aio-redis:
+        condition: service_started
+        required: false
+      nextcloud-aio-clamav:
+        condition: service_started
+        required: false
+      nextcloud-aio-fulltextsearch:
+        condition: service_started
+        required: false
+      nextcloud-aio-talk-recording:
+        condition: service_started
+        required: false
+      nextcloud-aio-imaginary:
+        condition: service_started
+        required: false
     image: nextcloud/aio-nextcloud:latest
     expose:
       - "9000"


### PR DESCRIPTION
Related discussion: #3085

Starting from docker-compose version v2.19.1 and newer, there is an enforced behavior where services listed under `depends_on:` are now **required** by default. This change cause issues when running a manual install without utilizing all the profiles. More information about this behavior can be found in the official documentation: https://docs.docker.com/compose/compose-file/05-services/#depends_on

To address this, I rewrote the `depends_on:` section using the long syntax and set `required: false`, excluding the services named _nextcloud-aio-nextcloud_ and _nextcloud-aio-database_ which I kept required.

Additionally, it might be worth considering setting `condition: service_healthy` for certain services, but I'm uncertain about the implications of doing so.