### PR TITLE
Allow networks to be created pre-emptively

### DIFF
--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -780,6 +780,19 @@ class DockerActionManager
             if ($e->getCode() !== 409) {
                 throw $e;
             }
+
+            // Network may have been created and connected preemptively
+            $url = $this->BuildApiUrl(sprintf('containers/%s/json', urlencode($id)));
+            try {
+                $response = $this->guzzleClient->get($url);
+                $responseBody = json_decode((string)$response->getBody(), true);
+                $connectedNetworks = $responseBody['NetworkSettings']['Networks'];
+                if (array_key_exists($network, $connectedNetworks)) {
+                    return;
+                }
+            } catch (RequestException $e) {
+                // do nothing
+            }
         }
 
         $url = $this->BuildApiUrl(


### PR DESCRIPTION
Currently, `nextcloud-aio-mastercontainer` will crash if the `nextcloud-aio` network already exists. This PR changes the behavior so that the `nextcloud-aio` network may be created preemptively.

I did this as a workaround to a bug in rootless Podman: https://github.com/containers/podman/issues/19577