### PR TITLE
Fix a small mistake in Traefik Docs

### DIFF
--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -541,7 +541,7 @@ The examples below define the dynamic configuration in YAML files. If you rather
     http:
         routers:
             nextcloud:
-                rule: "Host(<your-nextcloud-domain>)"
+                rule: "Host(`<your-nextcloud-domain>`)"
                 entrypoints:
                     - "https"
                 service: nextcloud


### PR DESCRIPTION
Description: This fixes a small mistake in the Traefik Reverse Proxy docs where is surroundes the domain in `` rather than leaving it not surrounded by anything.

This issue was discovered in this [discussion](https://github.com/nextcloud/all-in-one/discussions/3294) where I was trying to debug my own issue and found in the config.yml for traefik that the domain for nextcloud was not surrounded by `` and this led to errors being shown in the traefik dashboard as seen in the discussion post.