### PR TITLE
Revert "nextcloud container - make /tmp a tmpfs"

### DIFF
--- a/php/containers.json
+++ b/php/containers.json
@@ -217,9 +217,6 @@
       ],
       "networks": [
         "nextcloud-aio"
-      ],
-      "tmpfs": [
-        "/tmp:exec"
       ]
     },
     {


### PR DESCRIPTION
Reason: https://github.com/nextcloud/all-in-one/pull/2981#issuecomment-1715137673