### PR TITLE
FIX: use 1GB for FTS max JVM memory usage

### DIFF
--- a/php/containers.json
+++ b/php/containers.json
@@ -612,7 +612,7 @@
       "internal_port": "9200",
       "environment": [
         "TZ=%TIMEZONE%",
-        "ES_JAVA_OPTS=-Xms512M -Xmx512M",
+        "ES_JAVA_OPTS=-Xms512M -Xmx1024M",
         "bootstrap.memory_lock=true",
         "cluster.name=nextcloud-aio",
         "discovery.type=single-node",


### PR DESCRIPTION
Fix for #3354, this is the change I had to make in order for FTS to complete first indexing successfully (following this [discussion](https://github.com/nextcloud/all-in-one/discussions/2509) to re-index).  
Also, in the docs it is stated that FTS requires 1GB additional RAM, so I guess this -Xmx512M was not intended ?  

Fix https://github.com/nextcloud/all-in-one/discussions/3373