### PR TITLE
Remove backup app suggestion

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -376,7 +376,6 @@ Not directly but you have multiple options to achieve this:
 - Use rsync or rclone for syncing the borg backup archive that AIO creates locally to a remote target (make sure to lock the backup archive correctly before starting the sync; search for "aio-lockfile"; you can find a local example script here: https://github.com/nextcloud/all-in-one#sync-the-backup-regularly-to-another-drive)
 - You can find a well written guide that uses rclone and e.g. BorgBase for remote backups here: https://github.com/nextcloud/all-in-one/discussions/2247
 - create your own backup solution using a script and borg, borgmatic or any other to backup tool for backing up to a remote target (make sure to stop and start the AIO containers correctly following https://github.com/nextcloud/all-in-one#how-to-enable-automatic-updates-without-creating-a-backup-beforehand)
-- Additionally, there is the [backup app](https://apps.nextcloud.com/apps/backup) for remote backups
 
 ---
 


### PR DESCRIPTION
Remove suggestion to use Backup Nextcloud App as the app is no longer maintained, stable, or reliably works.