### PR TITLE
Revert "mastercontainer - use Caddy for generating self-singed cert"

### DIFF
--- a/Containers/mastercontainer/Caddyfile
+++ b/Containers/mastercontainer/Caddyfile
@@ -21,16 +21,7 @@
 }
 
 http://:80 {
-    redir https://{host}{uri}
-}
-
-https://:8080 {
-    reverse_proxy localhost:8000 {
-        trusted_proxies private_ranges
-    }
-    tls internal {
-        on_demand
-    }
+  redir https://{host}{uri}
 }
 
 https://:8443 {

--- a/Containers/mastercontainer/Dockerfile
+++ b/Containers/mastercontainer/Dockerfile
@@ -31,9 +31,10 @@ RUN set -ex; \
         bash \
         apache2 \
         apache2-proxy \
+        apache2-ssl \
         supervisor \
+        openssl \
         sudo \
-        nss \
         netcat-openbsd \
         curl \
         grep; \
@@ -64,7 +65,6 @@ RUN set -ex; \
     chmod +x /usr/local/bin/composer; \
     cd /var/www/docker-aio; \
     git clone https://github.com/nextcloud-releases/all-in-one.git --depth 1 .; \
-    apk del --no-cache git; \
     find ./ -maxdepth 1 -mindepth 1 -not -path ./php -not -path ./community-containers -exec rm -r {} \; ; \
     chown www-data:www-data -R /var/www/docker-aio; \
     cd php; \
@@ -76,6 +76,10 @@ RUN set -ex; \
     chown -R www-data:www-data /var/www; \
     rm -r php/data; \
     rm -r php/session; \
+    \
+    mkdir -p /etc/apache2/certs; \
+    cd /etc/apache2/certs; \
+    openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/C=DE/ST=BE/L=Local/O=Dev/CN=nextcloud.local" -keyout /etc/apache2/certs/ssl.key -out /etc/apache2/certs/ssl.crt; \
     \
     sed -i \
             -e '/^Listen /d' \
@@ -95,7 +99,13 @@ RUN set -ex; \
             -e 's/\(ScriptAlias \)/#\1/' \
         /etc/apache2/httpd.conf; \
         mkdir -p /etc/apache2/logs; \
+        rm /etc/apache2/conf.d/ssl.conf; \
         echo "ServerName localhost" | tee -a /etc/apache2/httpd.conf; \
+        grep -q '^LoadModule lbmethod_heartbeat_module' /etc/apache2/conf.d/proxy.conf; \
+        sed -i 's|^LoadModule lbmethod_heartbeat_module.*|#LoadModule lbmethod_heartbeat_module|' /etc/apache2/conf.d/proxy.conf; \
+        echo "SSLSessionCache nonenotnull" | tee -a /etc/apache2/httpd.conf; \
+        echo "LoadModule ssl_module modules/mod_ssl.so" | tee -a /etc/apache2/httpd.conf; \
+        echo "LoadModule socache_shmcb_module modules/mod_socache_shmcb.so" | tee -a /etc/apache2/httpd.conf; \
         echo "Include /etc/apache2/sites-available/mastercontainer.conf" | tee -a /etc/apache2/httpd.conf; \
     \
     rm -f /etc/apache2/conf.d/default.conf \

--- a/Containers/mastercontainer/mastercontainer.conf
+++ b/Containers/mastercontainer/mastercontainer.conf
@@ -38,6 +38,19 @@ Listen 8080
     </Directory>
 </VirtualHost>
 
+# Https host
+<VirtualHost *:8080>
+    # Proxy to https
+    ProxyPass / http://localhost:8000/
+    ProxyPassReverse / http://localhost:8000/
+    ProxyPreserveHost On
+    # SSL
+    SSLCertificateKeyFile /etc/apache2/certs/ssl.key
+    SSLCertificateFile /etc/apache2/certs/ssl.crt
+    SSLEngine               on
+    SSLProtocol             -all +TLSv1.2 +TLSv1.3
+</VirtualHost>
+
 # Increase timeout in case e.g. the initial download takes a long time
 Timeout 7200
 ProxyTimeout 7200

--- a/Containers/mastercontainer/start.sh
+++ b/Containers/mastercontainer/start.sh
@@ -300,6 +300,7 @@ fi
 mkdir -p /mnt/docker-aio-config/data/
 mkdir -p /mnt/docker-aio-config/session/
 mkdir -p /mnt/docker-aio-config/caddy/
+mkdir -p /mnt/docker-aio-config/certs/ 
 
 # Adjust permissions for all instances
 chmod 770 -R /mnt/docker-aio-config
@@ -307,6 +308,7 @@ chmod 777 /mnt/docker-aio-config
 chown www-data:www-data -R /mnt/docker-aio-config/data/
 chown www-data:www-data -R /mnt/docker-aio-config/session/
 chown www-data:www-data -R /mnt/docker-aio-config/caddy/
+chown root:root -R /mnt/docker-aio-config/certs/
 
 # Don't allow access to the AIO interface from the Nextcloud container
 # Probably more cosmetic than anything but at least an attempt
@@ -320,6 +322,22 @@ allow from all
 </Location>
 # nextcloud-aio-block-end
 APACHE_CONF
+fi
+
+# Adjust certs
+GENERATED_CERTS="/mnt/docker-aio-config/certs"
+TMP_CERTS="/etc/apache2/certs"
+mkdir -p "$GENERATED_CERTS"
+cd "$GENERATED_CERTS" || exit 1
+if ! [ -f ./ssl.crt ] && ! [ -f ./ssl.key ]; then
+    openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/C=DE/ST=BE/L=Local/O=Dev/CN=nextcloud.local" -keyout ./ssl.key -out ./ssl.crt
+fi
+if [ -f ./ssl.crt ] && [ -f ./ssl.key ]; then
+    cd "$TMP_CERTS" || exit 1
+    rm ./ssl.crt
+    rm ./ssl.key
+    cp "$GENERATED_CERTS/ssl.crt" ./
+    cp "$GENERATED_CERTS/ssl.key" ./
 fi
 
 print_green "Initial startup of Nextcloud All-in-One complete!


### PR DESCRIPTION
Reverts nextcloud/all-in-one#3416

due to https://github.com/nextcloud/all-in-one/pull/3416#issuecomment-1746670959