### PR TITLE
allow _ping docker api to verify service accessible

### DIFF
--- a/Containers/docker-socket-proxy/haproxy.cfg
+++ b/Containers/docker-socket-proxy/haproxy.cfg
@@ -9,6 +9,8 @@ frontend http
     mode http
     bind :::2375 v4v6
     http-request deny unless { src 127.0.0.1 } || { src ::1 } || { src NC_IPV4_PLACEHOLDER } || { src NC_IPV6_PLACEHOLDER }
+    # docker system _ping
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/_ping } METH_GET
     # container inspect: GET containers/%s/json
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/nc_app_[a-zA-Z0-9_.-]+/json } METH_GET
     # container start/stop: POST containers/%s/start containers/%s/stop

--- a/Containers/docker-socket-proxy/haproxy.cfg
+++ b/Containers/docker-socket-proxy/haproxy.cfg
@@ -32,7 +32,7 @@ frontend http
     http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/create } nc_app_container_name !one_mount_volume binds_present type_not_volume METH_POST
 
     # ACL to restrict container creation, that it has HostConfig.Privileged not set
-    acl no_privileged_flag req.body -m reg -i "\"HostConfig\":\s?{[^}]*\"Privileged\"\s*:"
+    acl no_privileged_flag req.body -m reg -i "\"HostConfig\":\s?{[^}]*\"Privileged\""
     # ACL to allow mount volume with strict pattern for name: nc_app_[a-zA-Z0-9_.-]+_data
     acl nc_app_volume_data_only req.body -m reg -i "\"Mounts\":\s?\[\s?{[^}]*\"Source\":\s?\"nc_app_[a-zA-Z0-9_.-]+_data\""
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/create } nc_app_container_name !no_privileged_flag nc_app_volume_data_only METH_POST


### PR DESCRIPTION
Allow `/_ping` api in docker-socket-proxy required for `app_api` to verify docker service connection.