### PR TITLE
local-ai - actually do not back up downloaded models

### DIFF
--- a/community-containers/local-ai/local-ai.json
+++ b/community-containers/local-ai/local-ai.json
@@ -37,9 +37,6 @@
                 "php /var/www/html/occ app:install integration_openai",
                 "php /var/www/html/occ config:app:set integration_openai url --value http://nextcloud-aio-local-ai:8080",
                 "php /var/www/html/occ app:install assistant"
-            ],
-            "backup_volumes": [
-                "nextcloud_aio_localai_models"
             ]
         }
     ]

--- a/community-containers/local-ai/readme.md
+++ b/community-containers/local-ai/readme.md
@@ -18,7 +18,6 @@ This container bundles Local AI and auto-configures it for you.
   name: gpt4all-j
 ```
 -  Additionally after doing so, you might want to enable or disable specific features for your models in the integration_openai settings: `https://your-nc-domain.com/settings/admin/connected-accounts`
-- The models folder where models get downloaded to is covered by AIOs backup solution
 - See https://github.com/nextcloud/all-in-one/tree/main/community-containers how to add it to the AIO stack
 
 ### Repository


### PR DESCRIPTION
Reason: They will be automatically downloaded by the container at any time.