### PR TITLE
do not catch error during pullcontainer so that it throws and logs if it cannot get the image

### DIFF
--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -577,14 +577,8 @@ class DockerActionManager
     public function PullContainer(Container $container) : void
     {
         $url = $this->BuildApiUrl(sprintf('images/create?fromImage=%s', urlencode($this->BuildImageName($container))));
-        try {
-            $this->guzzleClient->post($url);
-        } catch (RequestException $e) {
-            error_log('Could not get image ' . $this->BuildImageName($container) . ' from docker hub. Probably due to rate limits. ' . $e->getMessage());
-            // Don't exit here because it is possible that the image is already present 
-            // and we ran into docker hub limits.
-            // We will exit later if not image should be available.
-        }
+        // do not catch any exception so that it always throws and logs the error
+        $this->guzzleClient->post($url);
     }
 
     private function isContainerUpdateAvailable(string $id) : string


### PR DESCRIPTION
Make things like https://github.com/nextcloud/all-in-one/issues/3582 easier to debug