### PR TITLE
fix reference to column in wikipedia timezone list

### DIFF
--- a/Containers/postgresql/start.sh
+++ b/Containers/postgresql/start.sh
@@ -31,7 +31,7 @@ fi
 if [ -f "$DUMP_DIR/initialization.failed" ]; then
     echo "The database initialization failed. Most likely was a wrong timezone selected."
     echo "The selected timezone is '$TZ'." 
-    echo "Please check if it is in 'TZ database name' column of the timezone list: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List"
+    echo "Please check if it is in the 'TZ identifier' column of the timezone list: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List"
     echo "For further clues on what went wrong, look at the logs above."
     echo "You might start again from scratch by following https://github.com/nextcloud/all-in-one#how-to-properly-reset-the-instance and selecting a proper timezone."
     exit 1

--- a/php/templates/containers.twig
+++ b/php/templates/containers.twig
@@ -649,7 +649,7 @@
                                 <input type="hidden" name="{{csrf.keys.value}}" value="{{csrf.value}}">
                                 <input class="button" type="submit" value="Submit timezone" onclick="return confirm('Are you sure that this is a valid timezone? Please double check by following the wikipedia article and checking the correct column since if not, it will break the startup since the database will not get correctly initialized and you will end in a startup loop.')" />
                             </form>
-                            You need to make sure that the timezone that you enter is valid. An example is <b>Europe/Berlin</b>. You can get valid values by looking at the 'TZ database name' column of this list: <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List"><b>click here</b></a>. The default is <b>Etc/UTC</b> if nothing is entered.<br><br>
+                            You need to make sure that the timezone that you enter is valid. An example is <b>Europe/Berlin</b>. You can get valid values by looking at the 'TZ identifier' column of this list: <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List"><b>click here</b></a>. The default is <b>Etc/UTC</b> if nothing is entered.<br><br>
                         {% else %}
                             The timezone for Nextcloud is currently set to <b>{{ timezone }}</b>. You can reset the timezone again by clicking on the button below.<br><br/>
                             <form method="POST" action="/api/configuration" class="xhr">


### PR DESCRIPTION
https://github.com/nextcloud/all-in-one/blob/main/Containers/postgresql/start.sh has the same old text. I've used the GitHub web editor now so I'm not sure I can add that edit, but if preferred, I can `git clone` and fix that one too.