### PR TITLE
make sure that notify-push is executable

### DIFF
--- a/Containers/notify-push/start.sh
+++ b/Containers/notify-push/start.sh
@@ -46,6 +46,10 @@ fi
 export DATABASE_URL="postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST/$POSTGRES_DB"
 export REDIS_URL="redis://:$REDIS_HOST_PASSWORD@$REDIS_HOST"
 
+# Make the binary executable if possible
+ls -l /nextcloud/custom_apps/notify_push/bin/"$CPU_ARCH"/notify_push
+chmod +x /nextcloud/custom_apps/notify_push/bin/"$CPU_ARCH"/notify_push
+
 # Run it
 /nextcloud/custom_apps/notify_push/bin/"$CPU_ARCH"/notify_push \
     --database-prefix="oc_" \


### PR DESCRIPTION
Prevent things like https://help.nextcloud.com/t/aio-notify-push-container-does-not-start-permission-denied/171600/9
And https://github.com/nextcloud/all-in-one/discussions/3710
And https://github.com/nextcloud/all-in-one/issues/3727