### PR TITLE
Revert "Bump elasticsearch from 8.11.0 to 8.11.1 in /Containers/fullt…

### DIFF
--- a/Containers/fulltextsearch/Dockerfile
+++ b/Containers/fulltextsearch/Dockerfile
@@ -1,5 +1,5 @@
 # Probably from here https://github.com/elastic/elasticsearch/blob/main/distribution/docker/src/docker/Dockerfile
-FROM elasticsearch:8.11.1
+FROM elasticsearch:8.11.0
 
 USER root
 


### PR DESCRIPTION
…extsearch"

Reason: nor arm64 image is currently there