### PR TITLE
Fix collabora in manual-install Yaml

### DIFF
--- a/manual-install/latest.yml
+++ b/manual-install/latest.yml
@@ -198,6 +198,8 @@ services:
       - server_name=${NC_DOMAIN}
       - DONT_GEN_SSL_CERT=1
     restart: unless-stopped
+    cap_add:
+      - MKNOD
     profiles:
       - collabora
     networks:


### PR DESCRIPTION
Making it consistent with docs https://docs.nextcloud.com/server/stable/admin_manual/office/example-docker.html

When I ran compose with `--profile collabora` , Fiddling with logs showed me bunch of   "permission denied". Adding CAP_MKNOD fixes it