### PR TITLE
[breaking] - update aio-local-ai to v2

### DIFF
--- a/community-containers/local-ai/local-ai.json
+++ b/community-containers/local-ai/local-ai.json
@@ -5,7 +5,7 @@
             "display_name": "Local AI",
             "documentation": "https://github.com/nextcloud/all-in-one/tree/main/community-containers/local-ai",
             "image": "szaimen/aio-local-ai",
-            "image_tag": "v1",
+            "image_tag": "v2",
             "internal_port": "8080",
             "restart": "unless-stopped",
             "environment": [

--- a/community-containers/local-ai/readme.md
+++ b/community-containers/local-ai/readme.md
@@ -2,7 +2,8 @@
 This container bundles Local AI and auto-configures it for you.
 
 ### Notes
-- Make sure to have enough storage space available. This container alone needs ~14GB storage on x64, on arm64 only ~4GB. Every model that you add to `models.yaml` will of course use additional space which adds up quite fast.
+- This container does not work on arm64! If you add the container on arm64, it will fail to start because no image for arm64 is available!
+- Make sure to have enough storage space available. This container alone needs ~14GB storage. Every model that you add to `models.yaml` will of course use additional space which adds up quite fast.
 - After the container was started the first time, you should see a new `nextcloud-aio-local-ai` folder when you open the files app with the default `admin` user. In there you should see a `models.yaml` config file. You can now add models in there. Please refer [here](https://github.com/go-skynet/model-gallery/blob/main/index.yaml) where you can get further urls that you can put in there. Afterwards restart all containers from the AIO interface and the models should automatically get downloaded by the local-ai container and activated.
 - Example for content of `models.yaml` (if you add all of them, it takes around 10GB additional space):
 ```yaml


### PR DESCRIPTION
Breaking because they no longer ship Arm64 images and thus it can no longer run on arm64 and would fail to start in that case.

### TODO
- [x] wait for https://github.com/szaimen/aio-local-ai/pull/10
- [x] wait for the 28 release? (major version will increase)

Signed-off-by: Simon L <szaimen@e.mail.de>