### PR TITLE
Add Treafik HTTP/3 Support

### DIFF
--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -583,43 +583,9 @@ The examples below define the dynamic configuration in YAML files. If you rather
 
     ```yml
     http:
-        routers:
-            nextcloud:
-                rule: "Host(`<your-nc-domain>`)"
-                entrypoints:
-                    - "https"
-                service: nextcloud
-                middlewares:
-                    - nextcloud-chain
-                tls:
-                    certresolver: "letsencrypt"
-
-        services:
-            nextcloud:
-                loadBalancer:
-                    servers:
-                        - url: "http://localhost:11000" # Use the host's IP address if Traefik runs outside the host network
-
-        middlewares:
-            nextcloud-secure-headers:
-                headers:
-                    hostsProxyHeaders:
-                        - "X-Forwarded-Host"
-                    referrerPolicy: "same-origin"
-
-            https-redirect:
-                redirectscheme:
-                    scheme: https 
-   
-            nextcloud-chain:
-                chain:
-                    middlewares:
-                        # - ... (e.g. rate limiting middleware)
-                        - https-redirect
-                        - nextcloud-secure-headers
       routers:
         nextcloud:
-          rule: "Host(`<your-nextcloud-domain>`)"
+          rule: "Host(`<your-nc-domain>`)"
           entrypoints:
             - "https"
           service: nextcloud
@@ -627,27 +593,31 @@ The examples below define the dynamic configuration in YAML files. If you rather
             - nextcloud-chain
           tls:
             certresolver: "letsencrypt"
+
       services:
         nextcloud:
           loadBalancer:
             servers:
-              - url: "http://localhost:11000" # Use the host's IP address if Traefik runs outside the hostnetwork
+              - url: "http://localhost:11000" # Use the host's IP address if Traefik runs outside the host network
+
       middlewares:
         nextcloud-secure-headers:
           headers:
             hostsProxyHeaders:
               - "X-Forwarded-Host"
             referrerPolicy: "same-origin"
+
         https-redirect:
           redirectscheme:
             scheme: https 
-  
+
         nextcloud-chain:
           chain:
             middlewares:
               # - ... (e.g. rate limiting middleware)
               - https-redirect
               - nextcloud-secure-headers
+
     ```
 
 ---

--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -574,7 +574,7 @@ The examples below define the dynamic configuration in YAML files. If you rather
         directory: "/path/to/dynamic/conf" # Adjust the path according your needs.
         watch: true
 
-    # Enable HTTP/3 feature, don`t forget to route 443 UDP to Traefik (Firewall\NAT\Traefik Container) by uncommenting the lines below`
+    # Enable HTTP/3 feature by uncommenting the lines below. Don't forget to route 443 UDP to Traefik (Firewall\NAT\Traefik Container)
     # experimental:
       # http3: true
     ```

--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -574,9 +574,9 @@ The examples below define the dynamic configuration in YAML files. If you rather
         directory: "/path/to/dynamic/conf" # Adjust the path according your needs.
         watch: true
 
-    # Enable HTTP/3 feature, don`t forget to route 443 UDP to Traefik (Firewall\NAT\Traefik Container)`
-    experimental:
-      http3: true
+    # Enable HTTP/3 feature, don`t forget to route 443 UDP to Traefik (Firewall\NAT\Traefik Container) by uncommenting the lines below`
+    # experimental:
+      # http3: true
     ```
 
 1. Declare the router, service and middlewares for Nextcloud in `/path/to/dynamic/conf/nextcloud.yml`:

--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -558,8 +558,8 @@ The examples below define the dynamic configuration in YAML files. If you rather
     entryPoints:
       https:
         address: ":443" # Create an entrypoint called "https" that uses port 443
-        # If you want to enable HTTP/3 support, see below
-        http3: {}
+        # If you want to enable HTTP/3 support, uncomment the line below
+        # http3: {}
     
     certificatesResolvers:
       # Define "letsencrypt" certificate resolver

--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -617,7 +617,6 @@ The examples below define the dynamic configuration in YAML files. If you rather
               # - ... (e.g. rate limiting middleware)
               - https-redirect
               - nextcloud-secure-headers
-
     ```
 
 ---

--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -583,7 +583,6 @@ The examples below define the dynamic configuration in YAML files. If you rather
 
     ```yml
     http:
-<<<<<<< HEAD
         routers:
             nextcloud:
                 rule: "Host(`<your-nc-domain>`)"
@@ -618,7 +617,6 @@ The examples below define the dynamic configuration in YAML files. If you rather
                         # - ... (e.g. rate limiting middleware)
                         - https-redirect
                         - nextcloud-secure-headers
-=======
       routers:
         nextcloud:
           rule: "Host(`<your-nextcloud-domain>`)"
@@ -650,7 +648,6 @@ The examples below define the dynamic configuration in YAML files. If you rather
               # - ... (e.g. rate limiting middleware)
               - https-redirect
               - nextcloud-secure-headers
->>>>>>> 1e289d29 (Add Treafik HTTP/3 Support)
     ```
 
 ---

--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -556,27 +556,34 @@ The examples below define the dynamic configuration in YAML files. If you rather
     # STATIC CONFIGURATION
    
     entryPoints:
-        https:
-            address: ":443" # Create an entrypoint called "https" that uses port 443
+      https:
+        address: ":443" # Create an entrypoint called "https" that uses port 443
+        # If you want to enable HTTP/3 support, see below
+        http3: {}
     
     certificatesResolvers:
-        # Define "letsencrypt" certificate resolver
-        letsencrypt:
-            acme:
-                storage: /letsencrypt/acme.json # Defines the path where certificates should be stored
-                email: <your-email-address> # Where LE sends notification about certificates expiring
-                tlschallenge: true
+      # Define "letsencrypt" certificate resolver
+      letsencrypt:
+        acme:
+          storage: /letsencrypt/acme.json # Defines the path where certificates should be stored
+          email: <your-email-address> # Where LE sends notification about certificates expiring
+          tlschallenge: true
    
     providers:
-        file:
-            directory: "/path/to/dynamic/conf" # Adjust the path according your needs.
-            watch: true
+      file:
+        directory: "/path/to/dynamic/conf" # Adjust the path according your needs.
+        watch: true
+
+    # Enable HTTP/3 feature, don`t forget to route 443 UDP to Traefik (Firewall\NAT\Traefik Container)`
+    experimental:
+      http3: true
     ```
 
 1. Declare the router, service and middlewares for Nextcloud in `/path/to/dynamic/conf/nextcloud.yml`:
 
     ```yml
     http:
+<<<<<<< HEAD
         routers:
             nextcloud:
                 rule: "Host(`<your-nc-domain>`)"
@@ -611,6 +618,39 @@ The examples below define the dynamic configuration in YAML files. If you rather
                         # - ... (e.g. rate limiting middleware)
                         - https-redirect
                         - nextcloud-secure-headers
+=======
+      routers:
+        nextcloud:
+          rule: "Host(`<your-nextcloud-domain>`)"
+          entrypoints:
+            - "https"
+          service: nextcloud
+          middlewares:
+            - nextcloud-chain
+          tls:
+            certresolver: "letsencrypt"
+      services:
+        nextcloud:
+          loadBalancer:
+            servers:
+              - url: "http://localhost:11000" # Use the host's IP address if Traefik runs outside the hostnetwork
+      middlewares:
+        nextcloud-secure-headers:
+          headers:
+            hostsProxyHeaders:
+              - "X-Forwarded-Host"
+            referrerPolicy: "same-origin"
+        https-redirect:
+          redirectscheme:
+            scheme: https 
+  
+        nextcloud-chain:
+          chain:
+            middlewares:
+              # - ... (e.g. rate limiting middleware)
+              - https-redirect
+              - nextcloud-secure-headers
+>>>>>>> 1e289d29 (Add Treafik HTTP/3 Support)
     ```
 
 ---


### PR DESCRIPTION
Added documentation on how to enable HTTP/3 Support when using Traefik reverse proxy.

I found #3515 , if im not wrong we need to make http3 support configurable when using reverse proxy?

Also i can test against http3 support and it works but i think it only test for general support not if a service is using it activley ? I`m new to this topic