### PR TITLE
Include caldav/carddav rewrite in Traefik 2 documentation

### DIFF
--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -601,15 +601,21 @@ The examples below define the dynamic configuration in YAML files. If you rather
                         - "X-Forwarded-Host"
                     referrerPolicy: "same-origin"
 
+            nextcloud-dav:
+                replacepathregex:
+                    regex: "^/.well-known/ca(l|rd)dav"
+                    replacement: "/remote.php/dav/"
+
             https-redirect:
                 redirectscheme:
                     scheme: https 
-   
+
             nextcloud-chain:
                 chain:
                     middlewares:
                         # - ... (e.g. rate limiting middleware)
                         - https-redirect
+                        - nextcloud-dav
                         - nextcloud-secure-headers
     ```
 


### PR DESCRIPTION
I'm no Traefik expert, but I found [1] explaining how to implement the redirect using regex matching. I thought it was a pretty neat way of doing it :). 

Should be a nice addition to the documentation.

[1] https://community.traefik.io/t/nextcloud-with-cal-cardav-routing/5553/3