### PR TITLE
Correct pg_user name to oc_nextcloud

### DIFF
--- a/migration.md
+++ b/migration.md
@@ -33,7 +33,7 @@ The procedure for migrating the files and the database works like this:
         ```
     1. Create a new database by running:
         ```
-        export PG_USER="oc_nextcloud"
+        export PG_USER="ncadmin"
         export PG_PASSWORD="my-temporary-password"
         export PG_DATABASE="nextcloud_db"
         sudo -u postgres psql <<END
@@ -68,8 +68,8 @@ The procedure for migrating the files and the database works like this:
     1. Change it to look like this: `local::/mnt/ncdata/`.
     1. Now save the file by pressing `[CTRL] + [o]` then `[ENTER]` and close nano by pressing `[CTRL] + [x]`
     1. In order to make sure that everything is good, you can now run `grep "/your/old/datadir" database-dump.sql` which should not bring up further results.<br>
-    1. **Please note:** Unfortunately it is not possible to import a database dump from a former database owner with the name `nextcloud`. You can check if that is the case with this command: `grep "Name: oc_appconfig; Type: TABLE; Schema: public; Owner:" database-dump.sql | grep -oP 'Owner:.*$' | sed 's|Owner:||;s| ||g'`. If it returns `nextcloud`, you need to rename the owner in the dump file manually. A command like the following should work, however please note that it is possible that it will overwrite wrong lines. You can thus first check which lines it will change with `grep "Owner: nextcloud$" database-dump.sql`. If only correct looking lines get returned, feel free to change them with `sed -i 's|Owner: nextcloud$|Owner: oc_nextcloud|' database-dump.sql`.
-The same applies for the second statement, check with `grep " OWNER TO nextcloud;$" database-dump.sql` and replace with `sed -i 's| OWNER TO nextcloud;$| OWNER TO oc_nextcloud;|' database-dump.sql`.
+    1. **Please note:** Unfortunately it is not possible to import a database dump from a former database owner with the name `nextcloud`. You can check if that is the case with this command: `grep "Name: oc_appconfig; Type: TABLE; Schema: public; Owner:" database-dump.sql | grep -oP 'Owner:.*$' | sed 's|Owner:||;s| ||g'`. If it returns `nextcloud`, you need to rename the owner in the dump file manually. A command like the following should work, however please note that it is possible that it will overwrite wrong lines. You can thus first check which lines it will change with `grep "Owner: nextcloud$" database-dump.sql`. If only correct looking lines get returned, feel free to change them with `sed -i 's|Owner: nextcloud$|Owner: ncadmin|' database-dump.sql`.
+The same applies for the second statement, check with `grep " OWNER TO nextcloud;$" database-dump.sql` and replace with `sed -i 's| OWNER TO nextcloud;$| OWNER TO ncadmin;|' database-dump.sql`.
 1. Next, copy the database dump into the correct place and prepare the database container which will import from the database dump automatically the next container start: 
     ```
     sudo docker run --rm --volume nextcloud_aio_database_dump:/mnt/data:rw alpine rm /mnt/data/database-dump.sql

--- a/migration.md
+++ b/migration.md
@@ -6,7 +6,7 @@ There are basically three ways how to migrate from an already existing Nextcloud
 1. Migrate the files and the database which is much more complicated (and doesn't work on former snap installations)
 1. Use the user_migration app that allows to migrate some of the user's data from a former instance to a new instance but needs to be done manually for each user
 
-## Migrate only the files 
+## Migrate only the files
 **Please note**: If you used groupfolders or encrypted your files before, you will need to restore the database, as well!
 
 The procedure for migrating only the files works like this:
@@ -82,6 +82,9 @@ The same applies for the second statement, check with `grep " OWNER TO nextcloud
 1. Edit the Nextcloud AIO config.php file using `sudo docker run -it --rm --volume nextcloud_aio_nextcloud:/var/www/html:rw alpine sh -c "apk add --no-cache nano && nano /var/www/html/config/config.php"` and modify only `passwordsalt`, `secret`, `instanceid` and set it to the old values that you used on your old installation. If you are brave, feel free to modify further values e.g. add your old LDAP config or S3 storage config. (Some things like Mail server config can be added back using Nextcloud's webinterface later on).
 1. When you are done and saved your changes to the file, finally start the containers again and wait until all containers are running.
 1. As last step, install all apps again that were installed before on your old instance by using the webinterface.
+
+>[!Note]
+>`ncadmin` is a temporary PostgreSQL user, managed by the Nextcloud All-in-One setup for streamlined database management and temporary permissions in a secure environment.
 
 Now the whole Nextcloud instance should work again.<br>
 If not, feel free to restore the AIO instance from backup and start at step 8 again.

--- a/migration.md
+++ b/migration.md
@@ -33,7 +33,7 @@ The procedure for migrating the files and the database works like this:
         ```
     1. Create a new database by running:
         ```
-        export PG_USER="ncadmin"
+        export PG_USER="oc_nextcloud"
         export PG_PASSWORD="my-temporary-password"
         export PG_DATABASE="nextcloud_db"
         sudo -u postgres psql <<END
@@ -68,8 +68,8 @@ The procedure for migrating the files and the database works like this:
     1. Change it to look like this: `local::/mnt/ncdata/`.
     1. Now save the file by pressing `[CTRL] + [o]` then `[ENTER]` and close nano by pressing `[CTRL] + [x]`
     1. In order to make sure that everything is good, you can now run `grep "/your/old/datadir" database-dump.sql` which should not bring up further results.<br>
-    1. **Please note:** Unfortunately it is not possible to import a database dump from a former database owner with the name `nextcloud`. You can check if that is the case with this command: `grep "Name: oc_appconfig; Type: TABLE; Schema: public; Owner:" database-dump.sql | grep -oP 'Owner:.*$' | sed 's|Owner:||;s| ||g'`. If it returns `nextcloud`, you need to rename the owner in the dump file manually. A command like the following should work, however please note that it is possible that it will overwrite wrong lines. You can thus first check which lines it will change with `grep "Owner: nextcloud$" database-dump.sql`. If only correct looking lines get returned, feel free to change them with `sed -i 's|Owner: nextcloud$|Owner: ncadmin|' database-dump.sql`.
-The same applies for the second statement, check with `grep " OWNER TO nextcloud;$" database-dump.sql` and replace with `sed -i 's| OWNER TO nextcloud;$| OWNER TO ncadmin;|' database-dump.sql`.
+    1. **Please note:** Unfortunately it is not possible to import a database dump from a former database owner with the name `nextcloud`. You can check if that is the case with this command: `grep "Name: oc_appconfig; Type: TABLE; Schema: public; Owner:" database-dump.sql | grep -oP 'Owner:.*$' | sed 's|Owner:||;s| ||g'`. If it returns `nextcloud`, you need to rename the owner in the dump file manually. A command like the following should work, however please note that it is possible that it will overwrite wrong lines. You can thus first check which lines it will change with `grep "Owner: nextcloud$" database-dump.sql`. If only correct looking lines get returned, feel free to change them with `sed -i 's|Owner: nextcloud$|Owner: oc_nextcloud|' database-dump.sql`.
+The same applies for the second statement, check with `grep " OWNER TO nextcloud;$" database-dump.sql` and replace with `sed -i 's| OWNER TO nextcloud;$| OWNER TO oc_nextcloud;|' database-dump.sql`.
 1. Next, copy the database dump into the correct place and prepare the database container which will import from the database dump automatically the next container start: 
     ```
     sudo docker run --rm --volume nextcloud_aio_database_dump:/mnt/data:rw alpine rm /mnt/data/database-dump.sql


### PR DESCRIPTION
I recently transitioned my Nextcloud instance to Nextcloud AiO, following the guidelines outlined in [migration.md](https://github.com/nextcloud/all-in-one/blob/main/migration.md). 
These instructions recommend using the `pg_user` `ncadmin`.

To verify this, I queried all `pg_user` entries in the Postgres database created by the Nextcloud AiO Master container using the following command:

```bash
docker exec -it nextcloud-aio-database psql -U oc_nextcloud nextcloud_database -c "SELECT usename FROM pg_user;"
```

This query yielded the following results:

```text
   usename
--------------
 nextcloud
 oc_nextcloud
(2 rows)
```

Based on these findings, I modified the migration instructions to utilize the `pg_user` `oc_nextcloud` instead of `ncadmin`. 
With this adjustment, I successfully finished my migration process.

I did not try to use the `ncadmin` user.