### PR TITLE
Drop NET_RAW from all containers in manual

### DIFF
--- a/manual-install/latest.yml
+++ b/manual-install/latest.yml
@@ -45,6 +45,8 @@ services:
       - /usr/local/apache2/logs
       - /tmp
       - /home/www-data
+    cap_drop:
+      - NET_RAW
 
   nextcloud-aio-database:
     image: nextcloud/aio-postgresql:latest
@@ -68,6 +70,8 @@ services:
     read_only: true
     tmpfs:
       - /var/run/postgresql
+    cap_drop:
+      - NET_RAW
 
   nextcloud-aio-nextcloud:
     depends_on:
@@ -149,6 +153,8 @@ services:
     restart: unless-stopped
     networks:
       - nextcloud-aio
+    cap_drop:
+      - NET_RAW
 
   nextcloud-aio-notify-push:
     image: nextcloud/aio-notify-push:latest
@@ -170,6 +176,8 @@ services:
     networks:
       - nextcloud-aio
     read_only: true
+    cap_drop:
+      - NET_RAW
 
   nextcloud-aio-redis:
     image: nextcloud/aio-redis:latest
@@ -185,6 +193,8 @@ services:
     networks:
       - nextcloud-aio
     read_only: true
+    cap_drop:
+      - NET_RAW
 
   nextcloud-aio-collabora:
     image: nextcloud/aio-collabora:latest
@@ -205,6 +215,8 @@ services:
       - nextcloud-aio
     cap_add:
       - MKNOD
+    cap_drop:
+      - NET_RAW
 
   nextcloud-aio-talk:
     image: nextcloud/aio-talk:latest
@@ -234,6 +246,8 @@ services:
       - /opt/eturnal/run
       - /conf
       - /tmp
+    cap_drop:
+      - NET_RAW
 
   nextcloud-aio-talk-recording:
     image: nextcloud/aio-talk-recording:latest
@@ -255,6 +269,8 @@ services:
     tmpfs:
       - /tmp
       - /conf
+    cap_drop:
+      - NET_RAW
 
   nextcloud-aio-clamav:
     image: nextcloud/aio-clamav:latest
@@ -276,6 +292,8 @@ services:
       - /var/lock
       - /var/log/clamav
       - /tmp
+    cap_drop:
+      - NET_RAW
 
   nextcloud-aio-onlyoffice:
     image: nextcloud/aio-onlyoffice:latest
@@ -294,6 +312,8 @@ services:
       - onlyoffice
     networks:
       - nextcloud-aio
+    cap_drop:
+      - NET_RAW
 
   nextcloud-aio-imaginary:
     image: nextcloud/aio-imaginary:latest
@@ -305,6 +325,8 @@ services:
     restart: unless-stopped
     cap_add:
       - SYS_NICE
+    cap_drop:
+      - NET_RAW
     profiles:
       - imaginary
     networks:
@@ -336,6 +358,8 @@ services:
       - fulltextsearch
     networks:
       - nextcloud-aio
+    cap_drop:
+      - NET_RAW
 
 volumes:
   nextcloud_aio_apache:

--- a/php/containers-schema.json
+++ b/php/containers-schema.json
@@ -31,6 +31,13 @@
 							"pattern": "^[A-Z_]+$"
 						}
 					},
+					"cap_drop": {
+						"type": "array",
+						"items": {
+							"type": "string",
+							"pattern": "^[A-Z_]+$"
+						}
+					},
 					"depends_on": {
 						"type": "array",
 						"items": {

--- a/php/containers.json
+++ b/php/containers.json
@@ -65,6 +65,9 @@
         "/usr/local/apache2/logs",
         "/tmp",
         "/home/www-data"
+      ],
+      "cap_drop": [
+        "NET_RAW"
       ]
     },
     {
@@ -112,6 +115,9 @@
       "read_only": true,
       "tmpfs": [
         "/var/run/postgresql"
+      ],
+      "cap_drop": [
+        "NET_RAW"
       ]
     },
     {
@@ -226,6 +232,9 @@
       ],
       "networks": [
         "nextcloud-aio"
+      ],
+      "cap_drop": [
+        "NET_RAW"
       ]
     },
     {
@@ -263,7 +272,10 @@
       "networks": [
         "nextcloud-aio"
       ],
-      "read_only": true
+      "read_only": true,
+      "cap_drop": [
+        "NET_RAW"
+      ]
     },
     {
       "container_name": "nextcloud-aio-redis",
@@ -295,7 +307,10 @@
       "networks": [
         "nextcloud-aio"
       ],
-      "read_only": true
+      "read_only": true,
+      "cap_drop": [
+        "NET_RAW"
+      ]
     },
     {
       "container_name": "nextcloud-aio-collabora",
@@ -328,6 +343,9 @@
       ],
       "cap_add": [
         "MKNOD"
+      ],
+      "cap_drop": [
+        "NET_RAW"
       ]
     },
     {
@@ -380,6 +398,9 @@
         "/opt/eturnal/run",
         "/conf",
         "/tmp"
+      ],
+      "cap_drop": [
+        "NET_RAW"
       ]
     },
     {
@@ -414,6 +435,9 @@
       "tmpfs": [
         "/tmp",
         "/conf"
+      ],
+      "cap_drop": [
+        "NET_RAW"
       ]
     },
     {
@@ -472,6 +496,9 @@
       "cap_add": [
         "SYS_ADMIN"
       ],
+      "cap_drop": [
+        "NET_RAW"
+      ],
       "apparmor_unconfined": true,
       "read_only": true,
       "tmpfs": [
@@ -494,7 +521,10 @@
           "writeable": false
         }
       ],
-      "read_only": true
+      "read_only": true,
+      "cap_drop": [
+        "NET_RAW"
+      ]
     },
     {
       "container_name": "nextcloud-aio-domaincheck",
@@ -521,6 +551,9 @@
       "tmpfs": [
         "/etc/lighttpd",
         "/var/www/domaincheck"
+      ],
+      "cap_drop": [
+        "NET_RAW"
       ]
     },
     {
@@ -556,6 +589,9 @@
         "/var/lock",
         "/var/log/clamav",
         "/tmp"
+      ],
+      "cap_drop": [
+        "NET_RAW"
       ]
     },
     {
@@ -594,6 +630,9 @@
       ],
       "networks": [
         "nextcloud-aio"
+      ],
+      "cap_drop": [
+        "NET_RAW"
       ]
     },
     {
@@ -612,6 +651,9 @@
       "restart": "unless-stopped",
       "cap_add": [
         "SYS_NICE"
+      ],
+      "cap_drop": [
+        "NET_RAW"
       ],
       "profiles": [
         "imaginary"
@@ -662,6 +704,9 @@
       ],
       "secrets": [
         "FULLTEXTSEARCH_PASSWORD"
+      ],
+      "cap_drop": [
+        "NET_RAW"
       ]
     },
     {
@@ -685,6 +730,9 @@
       "read_only": true,
       "tmpfs": [
         "/tmp"
+      ],
+      "cap_drop": [
+        "NET_RAW"
       ]
     }
   ]


### PR DESCRIPTION
#3377 drops NET_RAW from all containers, but this doesn't appear to have been adopted into the manual mode.