### PR TITLE
hider server and x-powered-by header

### DIFF
--- a/Containers/apache/Caddyfile
+++ b/Containers/apache/Caddyfile
@@ -16,6 +16,8 @@
 
 https://{$ADDITIONAL_TRUSTED_DOMAIN}:443,
 {$PROTOCOL}://{$NC_DOMAIN}:{$APACHE_PORT} {
+    header -Server
+    header -X-Powered-By
 
     # Collabora
     route /browser/* {


### PR DESCRIPTION
I've changed the level of my NPMplus from error to warn today, now the log spams:
`upstream sent duplicate header line: "Server: Apache/2.4.58 (Unix)", previous value: "Server: Caddy", ignored while reading response header from upstream`
To fix, I think the Server header should be completely removed (so the apache and the caddy one). I also think the X-Powered-By header should be hidden, since it doesn't need to be public visible