### PR TITLE
Fix pi-hole dashboard page url

### DIFF
--- a/community-containers/pi-hole/readme.md
+++ b/community-containers/pi-hole/readme.md
@@ -6,7 +6,7 @@ This container bundles pi-hole and auto-configures it for you.
 - Make sure that no dns server is already running by checking with `sudo netstat -tulpn | grep 53`. Otherwise the container will not be able to start!
 - The DHCP functionality of Pi-hole has been disabled!
 - The data of pi-hole will be automatically included in AIOs backup solution!
-- After adding and starting the container, you can visit `http://ip.address.of.this.server:8573` in order to log in with the admin key that you can retrieve when running `sudo docker inspect nextcloud-aio-pihole | grep WEBPASSWORD`. There you can configure the pi-hole setup. Also you can add local dns records.
+- After adding and starting the container, you can visit `http://ip.address.of.this.server:8573/admin` in order to log in with the admin key that you can retrieve when running `sudo docker inspect nextcloud-aio-pihole | grep WEBPASSWORD`. There you can configure the pi-hole setup. Also you can add local dns records.
 - You can configure your home network now to use pi-hole as its dns server by configuring your router.
 - Additionally, you can configure the docker daemon to use that by editing `/etc/docker/daemon.json` and adding ` { "dns" : [ "ip.address.of.this.server" , "8.8.8.8" ] } `.
 - See https://github.com/nextcloud/all-in-one/tree/main/community-containers#community-containers how to add it to the AIO stack


### PR DESCRIPTION
The url provided in the readme returns a "403 Forbidden" error. The right page is `/admin`.

https://github.com/pi-hole/web?tab=readme-ov-file#post-installation-access-the-web-interface-and-gain-insight-into-your-networks-activity