### PR TITLE
fix: Do not apply an empty allow list if none is set

### DIFF
--- a/Containers/nextcloud/config/apps.config.php
+++ b/Containers/nextcloud/config/apps.config.php
@@ -12,5 +12,5 @@ $CONFIG = array (
               'writable' => true,
       ),
   ),
-  'appsallowlist' => getenv('APPS_ALLOWLIST') ? explode(" ", getenv('APPS_ALLOWLIST')) : [],
+  'appsallowlist' => getenv('APPS_ALLOWLIST') ? explode(" ", getenv('APPS_ALLOWLIST')) : false,
 );


### PR DESCRIPTION
Otherwise the empty array could block showing any apps from the store in apps management

