### PR TITLE
Add a jellyfin community-container

### DIFF
--- a/community-containers/caddy/readme.md
+++ b/community-containers/caddy/readme.md
@@ -1,5 +1,5 @@
 ## Caddy with geoblocking
-This container bundles caddy and auto-configures it for you. It also covers https://github.com/nextcloud/all-in-one/tree/main/community-containers/vaultwarden by listening on `bw.$NC_DOMAIN`, if installed. It also covers https://github.com/nextcloud/all-in-one/tree/main/community-containers/stalwart by listening on `mail.$NC_DOMAIN`, if installed.
+This container bundles caddy and auto-configures it for you. It also covers https://github.com/nextcloud/all-in-one/tree/main/community-containers/vaultwarden by listening on `bw.$NC_DOMAIN`, if installed. It also covers https://github.com/nextcloud/all-in-one/tree/main/community-containers/stalwart by listening on `mail.$NC_DOMAIN`, if installed. It also covers https://github.com/nextcloud/all-in-one/tree/main/community-containers/jellyfin by listening on `media.$NC_DOMAIN`, if installed.
 
 ### Notes
 - This container is incompatible with the [npmplus](https://github.com/nextcloud/all-in-one/tree/main/community-containers/npmplus) community container. So make sure that you do not enable both at the same time!

--- a/community-containers/jellyfin/jellyfin.json
+++ b/community-containers/jellyfin/jellyfin.json
@@ -1,0 +1,39 @@
+{
+    "aio_services_v1": [
+        {
+            "container_name": "nextcloud-aio-jellyfin",
+            "display_name": "Jellyfin",
+            "documentation": "https://github.com/nextcloud/all-in-one/tree/main/community-containers/jellyfin",
+            "image": "jellyfin/jellyfin",
+            "image_tag": "latest",
+            "internal_port": "host",
+            "restart": "unless-stopped",
+            "environment": [
+                "TZ=%TIMEZONE%"
+            ],
+            "volumes": [
+                {
+                    "source": "nextcloud_aio_jellyfin",
+                    "destination": "/config",
+                    "writeable": true
+                },
+                {
+                    "source": "%NEXTCLOUD_DATADIR%",
+                    "destination": "/media",
+                    "writeable": false
+                },
+                {
+                    "source": "%NEXTCLOUD_MOUNT%",
+                    "destination": "%NEXTCLOUD_MOUNT%",
+                    "writeable": false
+                }
+            ],
+            "devices": [
+                "/dev/dri"
+            ],
+            "backup_volumes": [
+                "nextcloud_aio_jellyfin"
+            ]
+        }
+    ]
+}

--- a/community-containers/jellyfin/readme.md
+++ b/community-containers/jellyfin/readme.md
@@ -2,10 +2,14 @@
 This container bundles Jellyfin and auto-configures it for you.
 
 ### Notes
-- This is not working on Docker Desktop since it needs `network_mode: host` in order to work correctly.
+- This container is incompatible with the [Plex](https://github.com/nextcloud/all-in-one/tree/main/community-containers/plex) community container. So make sure that you do not enable both at the same time!
+- This container does not work on Docker Desktop since it needs `network_mode: host` in order to work correctly.
 - After adding and starting the container, you can directly visit http://ip.address.of.server:8096/ and access your new Jellyfin instance!
-- The data of Jellyfin will be automatically included in AIOs backup solution!
-- See https://github.com/nextcloud/all-in-one/tree/main/community-containers#community-containers how to add it to the AIO stack
+- In order to access your Jellyfin outside the local network, you have to set up your own reverse proxy. You can set up a reverse proxy following [these instructions](https://github.com/nextcloud/all-in-one/blob/main/reverse-proxy.md) and [Jellyfin's networking documentation](https://jellyfin.org/docs/general/networking/#running-jellyfin-behind-a-reverse-proxy), OR use the [Caddy](https://github.com/nextcloud/all-in-one/tree/main/community-containers/caddy) community container that will automatically configure `media.$NC_DOMAIN` to redirect to your Jellyfin.
+- ⚠️ After the initial start, Jellyfin shows a configuration page to set up the root password, etc. **Be careful to initialize your Jellyfin before adding the DNS record.**
+- The data of Jellyfin will be automatically included in AIO's backup solution!
+- See [here](https://github.com/nextcloud/all-in-one/tree/main/community-containers#community-containers) how to add it to the AIO stack.
+
 
 ### Repository
 https://github.com/jellyfin/jellyfin

--- a/community-containers/jellyfin/readme.md
+++ b/community-containers/jellyfin/readme.md
@@ -4,7 +4,7 @@ This container bundles Jellyfin and auto-configures it for you.
 ### Notes
 - This is not working on Docker Desktop since it needs `network_mode: host` in order to work correctly.
 - After adding and starting the container, you can directly visit http://ip.address.of.server:8096/ and access your new Jellyfin instance!
-- The data of Plex will be automatically included in AIOs backup solution!
+- The data of Jellyfin will be automatically included in AIOs backup solution!
 - See https://github.com/nextcloud/all-in-one/tree/main/community-containers#community-containers how to add it to the AIO stack
 
 ### Repository

--- a/community-containers/jellyfin/readme.md
+++ b/community-containers/jellyfin/readme.md
@@ -1,0 +1,14 @@
+## Jellyfin
+This container bundles Jellyfin and auto-configures it for you.
+
+### Notes
+- This is not working on Docker Desktop since it needs `network_mode: host` in order to work correctly.
+- After adding and starting the container, you can directly visit http://ip.address.of.server:8096/ and access your new Jellyfin instance!
+- The data of Plex will be automatically included in AIOs backup solution!
+- See https://github.com/nextcloud/all-in-one/tree/main/community-containers#community-containers how to add it to the AIO stack
+
+### Repository
+https://github.com/jellyfin/jellyfin
+
+### Maintainer
+https://github.com/airopi

--- a/community-containers/plex/readme.md
+++ b/community-containers/plex/readme.md
@@ -2,6 +2,7 @@
 This container bundles Plex and auto-configures it for you.
 
 ### Notes
+- This container is incompatible with the [Jellyfin](https://github.com/nextcloud/all-in-one/tree/main/community-containers/jellyfin) community container. So make sure that you do not enable both at the same time!
 - This is not working on arm64 since Plex does only provide x64 docker images.
 - This is not working on Docker Desktop since it needs `network_mode: host` in order to work correctly.
 - If you have a firewall like ufw configured, you might need to open all Plex ports in there first in order to make it work. Especially port 32400 is important!


### PR DESCRIPTION
This is a new pull request that follows the previous one from @burnclouds, which has not been merged due to no responses. I just reused his work, with small fixes (removing a comma in the JSON).

https://github.com/nextcloud/all-in-one/pull/3634

This also follows the idea from @burnclouds: https://github.com/nextcloud/all-in-one/discussions/3500

The community-container works fine, but I was wondering if I can also add some "special rules" to the Caddy community-maintained container, so it adds a jellyfin subdomain to the server with HTTPS enabled? As it is the case for Bitwarden and Stalwart.