### PR TITLE
Add a clarifying comment to nginx.conf of reverse-proxy.md

### DIFF
--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -357,6 +357,7 @@ server {
         proxy_set_header Connection $connection_upgrade;
     }
 
+    #if running nginx on a subdomain (eg. nextcloud.example.com) of a domain that already has an wildcard ssl certificate from certbot on this machine, the <your-nc-domain> in the below lines should be replaced with just the domain (eg. example.com), not the subdomain. In this case the subdomain should already be secured without additional actions
     ssl_certificate /etc/letsencrypt/live/<your-nc-domain>/fullchain.pem;   # managed by certbot on host machine
     ssl_certificate_key /etc/letsencrypt/live/<your-nc-domain>/privkey.pem; # managed by certbot on host machine
 

--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -102,6 +102,10 @@ Add this as a new Apache site config:
     SSLCipherSuite          ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305
     SSLHonorCipherOrder     off
     SSLSessionTickets       off
+
+    # If running apache on a subdomain (eg. nextcloud.example.com) of a domain that already has an wildcard ssl certificate from certbot on this machine, 
+    # the <your-nc-domain> in the below lines should be replaced with just the domain (eg. example.com), not the subdomain. 
+    # In this case the subdomain should already be secured without additional actions
     SSLCertificateFile /etc/letsencrypt/live/<your-nc-domain>/fullchain.pem
     SSLCertificateKeyFile /etc/letsencrypt/live/<your-nc-domain>/privkey.pem
 
@@ -357,7 +361,9 @@ server {
         proxy_set_header Connection $connection_upgrade;
     }
 
-    #if running nginx on a subdomain (eg. nextcloud.example.com) of a domain that already has an wildcard ssl certificate from certbot on this machine, the <your-nc-domain> in the below lines should be replaced with just the domain (eg. example.com), not the subdomain. In this case the subdomain should already be secured without additional actions
+    # If running nginx on a subdomain (eg. nextcloud.example.com) of a domain that already has an wildcard ssl certificate from certbot on this machine, 
+    # the <your-nc-domain> in the below lines should be replaced with just the domain (eg. example.com), not the subdomain. 
+    # In this case the subdomain should already be secured without additional actions
     ssl_certificate /etc/letsencrypt/live/<your-nc-domain>/fullchain.pem;   # managed by certbot on host machine
     ssl_certificate_key /etc/letsencrypt/live/<your-nc-domain>/privkey.pem; # managed by certbot on host machine
 


### PR DESCRIPTION
In the example nginx.conf, if the user is running nextcloud on a subdomain of an already ssl secured domain, the <your-nc-domain> -placeholders should be replaced with eg. "sub.example.com" in server_name and just "example.com" in ssl-cert related lines. I added a comment clarifying this into the provided .conf