### PR TITLE
Disable Apache proxy buffering

### DIFF
--- a/Containers/apache/nextcloud.conf
+++ b/Containers/apache/nextcloud.conf
@@ -14,6 +14,9 @@ Listen 8000
         SetHandler "proxy:fcgi://${NEXTCLOUD_HOST}:9000"
     </FilesMatch>
 
+    <Proxy "fcgi://${NEXTCLOUD_HOST}:9000" flushpackets=on>
+    </Proxy>
+
     # Enable Brotli compression for js, css and svg files - other plain files are compressed by Nextcloud by default
     <IfModule mod_brotli.c>
         AddOutputFilterByType BROTLI_COMPRESS text/javascript application/javascript application/x-javascript text/css image/svg+xml


### PR DESCRIPTION
Disabling proxy buffering is necessary to use Server-sent events (SSE), which is what [NextPush](https://codeberg.org/NextPush/uppush) use.

Generally, proxy buffering can be used to reduce connection load on the backend server if you have clients with very poor connection. The proxy closes the connection to the server sooner and keep delivering data slowly to the client. The advantage is pretty limited without a load balancer (on the proxy).
Note that if a user has defined another reverse proxy in front, for example to add a load balancer, they will be able to add proxy buffering with an exception for certain paths if necessary there.

Another solution is to set *flushpackets* to *auto* with a very low *flushwait*, but in my opinion flushpackets=on is good enough.


Related issues and discussions:
https://codeberg.org/NextPush/nextpush-android/issues/4
https://codeberg.org/NextPush/uppush/issues/8 (probably)
https://github.com/UP-NextPush/android/issues/58
https://github.com/nextcloud/all-in-one/discussions/4295
https://github.com/nextcloud/all-in-one/discussions/4303
