### PR TITLE
Fixed a typo in containers.twig

### DIFF
--- a/php/templates/containers.twig
+++ b/php/templates/containers.twig
@@ -153,7 +153,7 @@
                                             <input class="button" type="submit" value="Check backup integrity"/><br/>
                                         </form>
                                     {% endif %}
-                                    Choose the backup that you want to restore and click on the button below to restore the selected backup. This will restore the whole AIO instance from backup. Please not that the current AIO password will be kept and the AIO password not restored from backup!<br><br>
+                                    Choose the backup that you want to restore and click on the button below to restore the selected backup. This will restore the whole AIO instance from backup. Please note that the current AIO password will be kept and the previous AIO password will not be restored from backup!<br><br>
                                     <form method="POST" action="/api/docker/restore" class="xhr" id="restore_selection">
                                         <input type="hidden" name="{{csrf.keys.name}}" value="{{csrf.name}}">
                                         <input type="hidden" name="{{csrf.keys.value}}" value="{{csrf.value}}">


### PR DESCRIPTION
I fixed the typo in #4428 and attempted to make the language a bit clearer around the AIO password when restoring a backup