### PR TITLE
fix(helm): image repo transformation yielding invalid yaml string syntax

### DIFF
--- a/nextcloud-aio-helm-chart/update-helm.sh
+++ b/nextcloud-aio-helm-chart/update-helm.sh
@@ -301,7 +301,7 @@ EOL
 find ./ -name '*apache-deployment.yaml' -exec sed -i "/^.*\- env:/r /tmp/additional-apache.config"  \{} \;
 
 # shellcheck disable=SC1083
-find ./ -name '*deployment.yaml' -exec sed -i 's|image: nextcloud/|image: "{{ .Values.IMAGE_MIRROR_PREFIX }}{{ .Values.NEXTCLOUD_IMAGE_ORG }}"/|' \{} \; 
+find ./ -name '*deployment.yaml' -exec sed -i 's|image: nextcloud/|image: "{{ .Values.IMAGE_MIRROR_PREFIX }}{{ .Values.NEXTCLOUD_IMAGE_ORG }}/|;s/$/"/;' \{} \;
 
 cd ../
 mkdir -p ../helm-chart/


### PR DESCRIPTION
**Did not test the update script! Please verify syntax etc.!**

Helm fails to install the release: `Error: YAML parse error on [...]: error converting YAML to JSON: yaml: line 42: did not find expected key`

### Broken

```yaml
image: "{{ .Values.IMAGE_MIRROR_PREFIX }}{{ .Values.NEXTCLOUD_IMAGE_ORG }}"/foo-bar:baz
```

### Working

```yaml
image: "{{ .Values.IMAGE_MIRROR_PREFIX }}{{ .Values.NEXTCLOUD_IMAGE_ORG }}/foo-bar:baz"
```