### PR TITLE
ci(lint-helm): fix paths syntax

### DIFF
--- a/.github/workflows/lint-helm.yml
+++ b/.github/workflows/lint-helm.yml
@@ -4,7 +4,8 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - 'nextcloud-aio-helm-chart/**'
+      - 'nextcloud-aio-helm-chart/**/*.yml'
+      - 'nextcloud-aio-helm-chart/**/*.yaml'
 
 jobs:
   lint-helm:

--- a/nextcloud-aio-helm-chart/templates/nextcloud-aio-clamav-deployment.yaml
+++ b/nextcloud-aio-helm-chart/templates/nextcloud-aio-clamav-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if eq .Values.CLAMAV_ENABLED "yes" }}
 apiVersion: apps/v1
-kind: Deployment
+kind: Deploymentfoobar
 metadata:
   annotations:
     kompose.cmd: kompose convert -c -f latest.yml --namespace "{{ .Values.NAMESPACE }}"


### PR DESCRIPTION
The syntax `foo/**` is not supported.

Ref https://github.blog/changelog/2019-09-30-github-actions-event-filtering-updates/