### PR TITLE
feat: enable HEIC+TIFF without Imaginary

### DIFF
--- a/Containers/nextcloud/Dockerfile
+++ b/Containers/nextcloud/Dockerfile
@@ -44,6 +44,8 @@ RUN set -ex; \
         icu-dev \
         imagemagick-dev \
         imagemagick-svg \
+        imagemagick-heic \
+        imagemagick-tiff \
         libevent-dev \
         libjpeg-turbo-dev \
         libmcrypt-dev \
@@ -211,6 +213,8 @@ RUN set -ex; \
         bind-tools \
         imagemagick \
         imagemagick-svg \
+        imagemagick-heic \
+        imagemagick-tiff \
         coreutils; \
     \
     grep -q '^pm = dynamic' /usr/local/etc/php-fpm.d/www.conf; \

--- a/Containers/nextcloud/start.sh
+++ b/Containers/nextcloud/start.sh
@@ -56,7 +56,7 @@ if [ -n "$ADDITIONAL_APKS" ]; then
     if ! [ -f "/additional-apks-are-installed" ]; then
         # Allow to disable imagemagick without having to download it each time
         if ! echo "$ADDITIONAL_APKS" | grep -q imagemagick; then
-            apk del imagemagick imagemagick-svg;
+            apk del imagemagick imagemagick-svg imagemagick-heic imagemagick-tiff;
         fi
         read -ra ADDITIONAL_APKS_ARRAY <<< "$ADDITIONAL_APKS"
         for app in "${ADDITIONAL_APKS_ARRAY[@]}"; do


### PR DESCRIPTION
Adds the required packages by default. Actually tiff is already present (at least right now) but good to be on the safe side.

1. Imaginary is not necessarily better. Actually slower for me.
2. This fails in a strange way: you can add the HEIC provider and it silently doesn't generate any previews.
3. There's no down side that I can think of

I've not tested the build but seems straightforward? Adding the `imagemagick-heic` package to a running container does fix the issue.

https://github.com/pulsejet/memories/issues/1120