### PR TITLE
allow logs endpoint in haproxy.cfg for docker-socket-proxy

### DIFF
--- a/Containers/docker-socket-proxy/haproxy.cfg
+++ b/Containers/docker-socket-proxy/haproxy.cfg
@@ -16,6 +16,8 @@ frontend http
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/_ping } METH_GET
     # container inspect: GET containers/%s/json
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/nc_app_[a-zA-Z0-9_.-]+/json } METH_GET
+    # container inspect: GET containers/%s/logs
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/nc_app_[a-zA-Z0-9_.-]+/logs } METH_GET
     # container start/stop: POST containers/%s/start containers/%s/stop
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/nc_app_[a-zA-Z0-9_.-]+/((start)|(stop)) } METH_POST
     # container rm: DELETE containers/%s


### PR DESCRIPTION
Recently we started to use Docker Engine API logs endpoint in AppAPI, this PR allow it in haproxy like in (https://github.com/cloud-py-api/docker-socket-proxy/pull/21/files#diff-f8584da92ddbd1d15b0e89ebc7248db5032c32af86900ba3981dae67482dc2e1R45).