### PR TITLE
Revert "Bump collabora/code from 24.04.1.4.1 to 24.04.2.1.1 in /Containers/collabora"

### DIFF
--- a/Containers/collabora/Dockerfile
+++ b/Containers/collabora/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:latest
 # From a file located probably somewhere here: https://github.com/CollaboraOnline/online/tree/master/docker
-FROM collabora/code:24.04.2.1.1
+FROM collabora/code:24.04.1.4.1
 
 USER root
 ARG DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Reverts nextcloud/all-in-one#4631

Reason: https://github.com/nextcloud-releases/all-in-one/actions/runs/9190919501/job/25276228878