### PR TITLE
Update add admin token

### DIFF
--- a/community-containers/stalwart/readme.md
+++ b/community-containers/stalwart/readme.md
@@ -15,7 +15,7 @@ This container bundles stalwart mail server and auto-configures it for you.
 - You need to configure a reverse proxy in order to run this container since stalwart needs a dedicated (sub)domain! For that, you might have a look at https://github.com/nextcloud/all-in-one/tree/main/community-containers/caddy.
 - Currently, only `mail.$NC_DOMAIN` is supported as subdomain! So if Nextcloud is using `your-domain.com`, Stalwart will use `mail.your-domain.com`.
 - The data of Stalwart will be automatically included in AIOs backup solution!
-- After adding and starting the container, you need to run `docker logs nextcloud-aio-stalwart` to obtain the system administrator account and password. With this information, you can log in to the web interface at `https://mail.your-domain.com/login`
+- After adding and starting the container, you need to run `docker inspect nextcloud-aio-stalwart  | grep STALWART_USER_PASS` to obtain the system administrator password (username: `admin`). With this information, you can log in to the web interface at `https://mail.your-domain.com/login`
 - See https://stalw.art/docs/install/docker/ for next steps.
 - Additionally, you might want to install and configure [snappymail](https://apps.nextcloud.com/apps/snappymail) or [mail](https://apps.nextcloud.com/apps/mail) inside Nextcloud in order to use your mail accounts for sending and retrieving mails.
 - See https://stalw.art/docs/faq for further faq and docs on the project

--- a/community-containers/stalwart/stalwart.json
+++ b/community-containers/stalwart/stalwart.json
@@ -48,7 +48,7 @@
             "environment": [
                 "TZ=%TIMEZONE%",
                 "NC_DOMAIN=%NC_DOMAIN%",
-                "ADMIN_SECRET=%STALWART_USER_PASS%"
+                "STALWART_USER_PASS=%STALWART_USER_PASS%"
             ],
             "secrets": [
                 "STALWART_USER_PASS"

--- a/community-containers/stalwart/stalwart.json
+++ b/community-containers/stalwart/stalwart.json
@@ -47,7 +47,11 @@
             ],
             "environment": [
                 "TZ=%TIMEZONE%",
-                "NC_DOMAIN=%NC_DOMAIN%"
+                "NC_DOMAIN=%NC_DOMAIN%",
+                "ADMIN_SECRET=%STALWART_USER_PASS%"
+            ],
+            "secrets": [
+                "STALWART_USER_PASS"
             ],
             "volumes": [
                 {


### PR DESCRIPTION
Some configuration in Stalwart was missing 
See https://github.com/marcoambrosini/aio-stalwart/pull/20/commits/7e37220fc7f881a8aa7a1e66ce27b31c937b3c75

It also lacks the admin password… But I don't know if it's proper to do it like that.