### PR TITLE
nextcloud: increase the default_socket_timeout

### DIFF
--- a/Containers/nextcloud/Dockerfile
+++ b/Containers/nextcloud/Dockerfile
@@ -118,6 +118,7 @@ RUN set -ex; \
         echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
         echo 'max_execution_time=${PHP_MAX_TIME}'; \
         echo 'max_input_time=${PHP_MAX_TIME}'; \
+        echo 'default_socket_timeout=600'; \
     } > /usr/local/etc/php/conf.d/nextcloud.ini; \
     \
     { \


### PR DESCRIPTION
- https://help.nextcloud.com/t/getting-errors-from-files-antivirus-app/191971
- https://github.com/nextcloud/files_antivirus/issues/261#issuecomment-1847355924