### PR TITLE
nextcloud: add igbinary as serializer for increased performance

### DIFF
--- a/.github/workflows/nextcloud-update.yml
+++ b/.github/workflows/nextcloud-update.yml
@@ -36,7 +36,7 @@ jobs:
             | sort -V \
             | tail -1
         )"
-        sed -i "s|pecl install memcached.*\;|pecl install memcached-$memcached_version\;|" ./Containers/nextcloud/Dockerfile
+        sed -i "s|pecl install memcached.* |pecl install memcached-$memcached_version |" ./Containers/nextcloud/Dockerfile
         
         # Redis
         redis_version="$(
@@ -47,7 +47,7 @@ jobs:
             | sort -V \
             | tail -1
         )"
-        sed -i "s|pecl install redis.*\;|pecl install redis-$redis_version\;|" ./Containers/nextcloud/Dockerfile
+        sed -i "s|pecl install redis.* |pecl install redis-$redis_version |" ./Containers/nextcloud/Dockerfile
         
         # Imagick
         imagick_version="$(
@@ -59,6 +59,17 @@ jobs:
             | tail -1
         )"
         sed -i "s|pecl install imagick.*\;|pecl install imagick-$imagick_version\;|" ./Containers/nextcloud/Dockerfile
+
+        # Igbinary
+        igbinary_version="$(
+          git ls-remote --tags https://github.com/igbinary/igbinary.git \
+            | cut -d/ -f3 \
+            | grep -viE '[a-z]' \
+            | tr -d '^{}' \
+            | sort -V \
+            | tail -1
+        )"
+        sed -i "s|pecl install igbinary.*\;|pecl install igbinary-$igbinary_version\;|" ./Containers/nextcloud/Dockerfile
 
         # Nextcloud
         NC_MAJOR="$(grep "ENV NEXTCLOUD_VERSION" ./Containers/nextcloud/Dockerfile | grep -oP '[23][0-9]')"

--- a/Containers/nextcloud/Dockerfile
+++ b/Containers/nextcloud/Dockerfile
@@ -80,12 +80,10 @@ RUN set -ex; \
 # pecl will claim success even if one install fails, so we need to perform each install separately
     pecl install igbinary-3.2.15; \ 
     pecl install APCu-5.1.23; \
-    pecl install --configureoptions \
-        'enable-memcached-igbinary="yes"' \
-        memcached-3.2.0; \
-    pecl install --configureoptions \
-        'enable-redis-igbinary="yes" enable-redis-zstd="yes" enable-redis-lz4="yes"' \
-        redis-6.0.2; \
+    pecl install memcached-3.2.0 \
+        --configureoptions 'enable-memcached-igbinary="yes"'; \
+    pecl install redis-6.0.2 \
+        --configureoptions 'enable-redis-igbinary="yes" enable-redis-zstd="yes" enable-redis-lz4="yes"'; \
     pecl install imagick-3.7.0; \
     \
     docker-php-ext-enable \

--- a/Containers/nextcloud/Dockerfile
+++ b/Containers/nextcloud/Dockerfile
@@ -78,12 +78,18 @@ RUN set -ex; \
     ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately
+    pecl install igbinary-3.2.15; \ 
     pecl install APCu-5.1.23; \
-    pecl install memcached-3.2.0; \
-    pecl install redis-6.0.2; \
+    pecl install --configureoptions \
+        'enable-memcached-igbinary="yes"' \
+        memcached-3.2.0; \
+    pecl install --configureoptions \
+        'enable-redis-igbinary="yes" enable-redis-zstd="yes" enable-redis-lz4="yes"' \
+        redis-6.0.2; \
     pecl install imagick-3.7.0; \
     \
     docker-php-ext-enable \
+        igbinary \
         apcu \
         memcached \
         redis \
@@ -98,6 +104,11 @@ RUN set -ex; \
     )"; \
     apk add --no-cache --virtual .nextcloud-phpext-rundeps $runDeps; \
     apk del .build-deps; \
+    \
+    { \
+        echo 'apc.serializer=igbinary'; \
+        echo 'session.serialize_handler=igbinary'; \
+    } >> /usr/local/etc/php/conf.d/docker-php-ext-igbinary.ini; \
     \
 # set recommended PHP.ini settings
 # see https://docs.nextcloud.com/server/stable/admin_manual/configuration_server/server_tuning.html#enable-php-opcache


### PR DESCRIPTION
- Install igbinary via PECL
- Enable igbinary support for memcached and redis
- Configure PHP to use igbinary for APCu and session serialization
- Update Dockerfile to include igbinary and its configuration