### PR TITLE
Implement internal mode

### DIFF
--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -137,7 +137,7 @@ class DockerActionManager
         } elseif($internalPort === '%TALK_PORT%') {
             $internalPort = $this->configurationManager->GetTalkPort();
         }
-        
+
         if ($internalPort !== "" && $internalPort !== 'host') {
             $connection = @fsockopen($containerName, (int)$internalPort, $errno, $errstr, 0.2);
             if ($connection) {
@@ -438,7 +438,7 @@ class DockerActionManager
         $requestBody['HostConfig']['RestartPolicy']['Name'] = $container->GetRestartPolicy();
 
         $requestBody['HostConfig']['ReadonlyRootfs'] = $container->GetReadOnlySetting();
- 
+
         $exposedPorts = [];
         if ($container->GetInternalPort() !== 'host') {
             foreach($container->GetPorts()->GetPorts() as $value) {
@@ -478,6 +478,10 @@ class DockerActionManager
                 $ipBinding = $value->ipBinding;
                 if ($ipBinding === '%APACHE_IP_BINDING%') {
                     $ipBinding = $this->configurationManager->GetApacheIPBinding();
+                    // Do not expose if AIO is in internal network mode
+                    if ($ipBinding === '@INTERNAL') {
+                        continue;
+                    }
                 }
                 $portWithProtocol = $port . '/' . $protocol;
                 $requestBody['HostConfig']['PortBindings'][$portWithProtocol] = [
@@ -708,7 +712,7 @@ class DockerActionManager
             if (!isset($imageOutput['RepoDigests'])) {
                 error_log('RepoDigests is not set of container ' . $containerName);
                 return null;
-            } 
+            }
 
             if (!is_array($imageOutput['RepoDigests'])) {
                 error_log('RepoDigests of ' . $containerName . ' is not an array which is not allowed!');

--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -8,6 +8,8 @@ A [reverse proxy](https://en.wikipedia.org/wiki/Reverse_proxy) is basically a we
 
 In order to run Nextcloud behind a web server or reverse proxy (like Apache, Nginx, Cloudflare Tunnel and else), you need to specify the port that AIO's Apache container shall use, add a specific config to your web server or reverse proxy and modify the startup command a bit. All examples below will use port `11000` as example `APACHE_PORT` which will be exposed on the host to receive unencrypted HTTP traffic from the reverse proxy. **Advice:** If you need https between Nextcloud and the reverse proxy because it is running on a different server in the same network, simply add another reverse proxy to the chain that runs on the same server like AIO and takes care of https proxying (most likely via self-signed cert). Another option is to create a VPN between the server that runs AIO and the server that runs the reverse proxy which takes care of encrypting the connection.
 
+If you are using a reverse proxy attached to the `nextcloud-aio` virtual network (like the [caddy community container](https://github.com/nextcloud/all-in-one/tree/main/community-containers/caddy)), you can set the `APACHE_IP_BINDING` to `@INTERNAL` to disable the exposure of the Apache container to the host network.
+
 **Attention:** The process to run Nextcloud behind a reverse proxy consists of at least steps 1, 2 and 4:
 1. **Configure the reverse proxy! See [point 1](#1-configure-the-reverse-proxy)**
 1. **Use this startup command! See [point 2](#2-use-this-startup-command)**


### PR DESCRIPTION
It allows you not to expose AIO servers when you use reverse proxy attach in the docker aio network.

It is useful for filtered all AIO services access (with Forward Auth and Community Container).
And it prevents the proxy from bypass.

Sample compose.yaml:
```yaml
services:
  nextcloud-aio-mastercontainer:
    image: nextcloud/all-in-one:latest
    init: true
    restart: always
    container_name: nextcloud-aio-mastercontainer
    volumes:
      - nextcloud_aio_mastercontainer:/mnt/docker-aio-config
      - /var/run/docker.sock:/var/run/docker.sock:ro
    ports:
      - 127.0.0.1:8080:8080
    environment:
      - APACHE_IP_BINDING=@INTERNAL
    networks:
      - nextcloud-aio

  caddy:
    image: caddy:alpine
    restart: always
    container_name: caddy
    volumes:
      - ./Caddyfile:/etc/caddy/Caddyfile
    ports:
      - 80:80
      - 433:433
    networks:
      - nextcloud-aio

volumes:
 nextcloud_aio_mastercontainer:
   name: nextcloud_aio_mastercontainer

networks:
  nextcloud-aio:
    name: nextcloud-aio
```

I do not think that services exposed on the host is a real issue, but in terms of security and isolation it is an appropriate improvement.