### PR TITLE
Update reverse-proxy.md

### DIFF
--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -91,7 +91,7 @@ Add this as a new Apache site config:
     RewriteCond %{HTTP:Upgrade} websocket [NC]
     RewriteCond %{HTTP:Connection} upgrade [NC]
     RewriteCond %{THE_REQUEST} "^[a-zA-Z]+ /(.*) HTTP/\d+(\.\d+)?$"
-    RewriteRule .? "ws://localhost:11000/%1" [P,L]
+    RewriteRule .? "ws://localhost:11000/%1" [P,L,UnsafeAllow3F]
 
     # Enable h2, h2c and http1.1
     Protocols h2 h2c http/1.1


### PR DESCRIPTION
Users running AIO on Ubuntu Jammy may face blocked web socket traffic trough Apache, since rewrites with "?" are deemed unsafe. A error like this can be found in the error logs: "[rewrite:error] [pid396674] [client 192.168.xxx.yyy:57444] AH: Unsafe URL with %3f URL rewritten without UnsafeAllow3F" The rewrite rule UnsafeAllow3F is fixing this issue. Infos on that flag can be found here: https://httpd.apache.org/docs/current/rewrite/flags.html#flag_unsafe_allow_3f