### PR TITLE
get rid of "some font thing failed" error messages

### DIFF
--- a/Containers/imaginary/Dockerfile
+++ b/Containers/imaginary/Dockerfile
@@ -25,6 +25,7 @@ RUN set -ex; \
         vips-heif \
         vips-jxl \
         vips-poppler \
+        ttf-dejavu \
         bash
 
 COPY --from=go /go/bin/imaginary /usr/local/bin/imaginary


### PR DESCRIPTION
Added the line:
```
28 +        ttf-dejavu \
```
Converted line endings from DOS to Unix. Please use "Ignore whitespace" to see the actual change.

ernolf