### PR TITLE
fix: remove unused go binaries from redis and postgresql images

### DIFF
--- a/Containers/apache/Dockerfile
+++ b/Containers/apache/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:latest
 FROM caddy:2.8.4-alpine AS caddy
 
+# From https://github.com/docker-library/httpd/blob/master/2.4/alpine/Dockerfile
 FROM httpd:2.4.61-alpine3.20
 
 COPY --from=caddy /usr/bin/caddy /usr/bin/caddy

--- a/Containers/postgresql/Dockerfile
+++ b/Containers/postgresql/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:latest
-# From https://github.com/docker-library/postgres/blob/master/15/alpine/Dockerfile
+# From https://github.com/docker-library/postgres/blob/master/16/alpine3.20/Dockerfile
 FROM postgres:16.3-alpine
 
 COPY --chmod=775 start.sh /start.sh

--- a/Containers/postgresql/Dockerfile
+++ b/Containers/postgresql/Dockerfile
@@ -35,7 +35,7 @@ RUN set -ex; \
     apk --no-cache del openssl; \
     \
 # Get rid of unused binaries
-    rm /usr/local/bin/gosu /usr/local/bin/su-exec;
+    rm -f /usr/local/bin/gosu /usr/local/bin/su-exec;
 
 VOLUME /mnt/data
 

--- a/Containers/postgresql/Dockerfile
+++ b/Containers/postgresql/Dockerfile
@@ -32,7 +32,10 @@ RUN set -ex; \
     \
 # Give root a random password
     echo "root:$(openssl rand -base64 12)" | chpasswd; \
-    apk --no-cache del openssl;
+    apk --no-cache del openssl; \
+    \
+# Get rid of unused binaries
+    rm /usr/local/bin/gosu /usr/local/bin/su-exec;
 
 VOLUME /mnt/data
 

--- a/Containers/redis/Dockerfile
+++ b/Containers/redis/Dockerfile
@@ -12,7 +12,7 @@ RUN set -ex; \
     echo "root:$(openssl rand -base64 12)" | chpasswd; \
     \
 # Get rid of unused binaries
-    rm /usr/local/bin/gosu;
+    rm -f /usr/local/bin/gosu;
 
 USER redis
 ENTRYPOINT ["/start.sh"]

--- a/Containers/redis/Dockerfile
+++ b/Containers/redis/Dockerfile
@@ -9,7 +9,10 @@ RUN set -ex; \
     apk add --no-cache openssl bash; \
     \
 # Give root a random password
-    echo "root:$(openssl rand -base64 12)" | chpasswd
+    echo "root:$(openssl rand -base64 12)" | chpasswd; \
+    \
+# Get rid of unused binaries
+    rm /usr/local/bin/gosu;
 
 USER redis
 ENTRYPOINT ["/start.sh"]

--- a/Containers/redis/Dockerfile
+++ b/Containers/redis/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:latest
-# From https://github.com/docker-library/redis/blob/master/7.0/alpine/Dockerfile
+# From https://github.com/docker-library/redis/blob/master/7.2/alpine/Dockerfile
 FROM redis:7.2.5-alpine
 
 COPY --chmod=775 start.sh /start.sh


### PR DESCRIPTION
Both binaries gosu and su-exec are not used in our entrypoints.