### PR TITLE
Document AIO_URL

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -13,6 +13,7 @@ services:
       - 8080:8080
       - 8443:8443 # Can be removed when running behind a web server or reverse proxy (like Apache, Nginx, Caddy, Cloudflare Tunnel and else). See https://github.com/nextcloud/all-in-one/blob/main/reverse-proxy.md
     # environment: # Is needed when using any of the options below
+      # AIO_URL: localhost # The URL under which the AIO interface is available. By default it lives on localhost behind port 8080. If you want to run it, e.g., behind a reverse proxy, you can adjust this variable to the proxied URL.
       # AIO_DISABLE_BACKUP_SECTION: false # Setting this to true allows to hide the backup section in the AIO interface. See https://github.com/nextcloud/all-in-one#how-to-disable-the-backup-section
       # APACHE_PORT: 11000 # Is needed when running behind a web server or reverse proxy (like Apache, Nginx, Caddy, Cloudflare Tunnel and else). See https://github.com/nextcloud/all-in-one/blob/main/reverse-proxy.md
       # APACHE_IP_BINDING: 127.0.0.1 # Should be set when running behind a web server or reverse proxy (like Apache, Nginx, Caddy, Cloudflare Tunnel and else) that is running on the same host. See https://github.com/nextcloud/all-in-one/blob/main/reverse-proxy.md


### PR DESCRIPTION
`AIO_URL` is part of the Nextcloud container: https://github.com/nextcloud/all-in-one/blob/41e6d7cf6d2330e695b26ada5eca2a25634d91b9/Containers/nextcloud/Dockerfile#L12
When running the AIO interface, e.g., behind a reverse proxy, one can change this variable to the proxied URL.