### PR TITLE
apache: re-enable content-length header

### DIFF
--- a/Containers/apache/nextcloud.conf
+++ b/Containers/apache/nextcloud.conf
@@ -51,4 +51,7 @@ Listen 8000
 
     # See https://httpd.apache.org/docs/trunk/mod/core.html#traceenable
     TraceEnable Off
+
+    # See https://github.com/nextcloud/server/issues/47017#issuecomment-2267102392
+    SetEnv ap_trust_cgilike_cl
 </VirtualHost>


### PR DESCRIPTION
- See https://github.com/nextcloud/server/issues/47017
- See https://help.nextcloud.com/t/no-indication-of-download-progress-or-eta-when-donwloading-big-files-from-nextcloud-aio/200261