### PR TITLE
helm-chart: Allow users to change apache service type

### DIFF
--- a/nextcloud-aio-helm-chart/templates/nextcloud-aio-apache-service.yaml
+++ b/nextcloud-aio-helm-chart/templates/nextcloud-aio-apache-service.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: "{{ .Values.NAMESPACE }}"
 spec:
   ipFamilyPolicy: PreferDualStack
-  type: LoadBalancer
+  type: {{ .Values.APACHE_SERVICE_TYPE }}
   externalTrafficPolicy: Local
   ports:
     - name: "{{ .Values.APACHE_PORT }}"

--- a/nextcloud-aio-helm-chart/values.yaml
+++ b/nextcloud-aio-helm-chart/values.yaml
@@ -21,6 +21,7 @@ TALK_RECORDING_ENABLED: "no"          # Setting this to "yes" (with quotes) enab
 
 APACHE_MAX_SIZE: "10737418240"          # This needs to be an integer and in sync with NEXTCLOUD_UPLOAD_LIMIT
 APACHE_PORT: 443          # Changing this to a different value than 443 will allow you to run it behind a web server or reverse proxy (like Apache, Nginx, Caddy, Cloudflare Tunnel and else).
+APACHE_SERVICE_TYPE: LoadBalancer          # This needs to be a valid Kubernetes service type like LoadBalancer or ClusterIP. If you plan to use Nextcloud behind an ingress controller, this may be ClusterIP.
 COLLABORA_DICTIONARIES: de_DE en_GB en_US es_ES fr_FR it nl pt_BR pt_PT ru        # You can change this in order to enable other dictionaries for collabora
 COLLABORA_SECCOMP_POLICY: --o:security.seccomp=true          # Changing the value to false allows to disable the seccomp feature of the Collabora container.
 INSTALL_LATEST_MAJOR: no        # Setting this to yes will install the latest Major Nextcloud version upon the first installation


### PR DESCRIPTION
I am using nextcloud-aio via the Helm chart in a Kubernetes environment. As I am using Nextcloud behind a kubernetes ingress controller, there is no need for my nextcloud-aio-apache to be a LoadBalancer service. As I have no Load Balancer IP addresses free, nextcloud-aio-apache service is pending (and so is the `helm install`) until I manually change the type to `ClusterIP`.

Therefore I introduced a helm variable to change the apache service type.