### PR TITLE
docs: remove hint that network_mode host does not work on Docker Desktop

### DIFF
--- a/community-containers/dlna/readme.md
+++ b/community-containers/dlna/readme.md
@@ -3,7 +3,6 @@ This container bundles DLNA server for your Nextcloud files to be accessible by 
 
 ### Notes
 - This container will work only if the Nextcloud installation is in your home network, it is not suitable for installations on remote servers.
-- This is not working with Docker Desktop since it requires the `host` networking mode in docker, and it doesn't really share the host's network interfaces in this system
 - If you have a firewall like ufw configured, you might need to open at least port 9999 TCP and 1900 UDP first in order to make it work.
 - See https://github.com/nextcloud/all-in-one/tree/main/community-containers#community-containers how to add it to the AIO stack
 

--- a/community-containers/fail2ban/readme.md
+++ b/community-containers/fail2ban/readme.md
@@ -2,7 +2,6 @@
 This container bundles fail2ban and auto-configures it for you in order to block ip-addresses automatically. It also covers https://github.com/nextcloud/all-in-one/tree/main/community-containers/vaultwarden, if installed.
 
 ### Notes
-- This is not working on Docker Desktop since it needs `network_mode: host` in order to work correctly.
 - If you get an error like `"ip6tables v1.8.9 (legacy): can't initialize ip6tables table filter': Table does not exist (do you need to insmod?)"`, you need to enable ip6tables on your host via `sudo modprobe ip6table_filter`.
 - If you get an error like  `stderr: 'iptables: No chain/target/match by that name.'` and `stderr: 'ip6tables: No chain/target/match by that name.'`, you need to follow https://github.com/szaimen/aio-fail2ban/issues/9#issuecomment-2026898790 in order to resolve this.
 - See https://github.com/nextcloud/all-in-one/tree/main/community-containers#community-containers how to add it to the AIO stack

--- a/community-containers/jellyfin/readme.md
+++ b/community-containers/jellyfin/readme.md
@@ -3,7 +3,6 @@ This container bundles Jellyfin and auto-configures it for you.
 
 ### Notes
 - This container is incompatible with the [Plex](https://github.com/nextcloud/all-in-one/tree/main/community-containers/plex) community container. So make sure that you do not enable both at the same time!
-- This container does not work on Docker Desktop since it needs `network_mode: host` in order to work correctly.
 - After adding and starting the container, you can directly visit http://ip.address.of.server:8096/ and access your new Jellyfin instance!
 - This container should usually only be run in home networks as it exposes unencrypted services like DLNA by default which can be disabld via the web interface though.
 - In order to access your Jellyfin outside the local network, you have to set up your own reverse proxy. You can set up a reverse proxy following [these instructions](https://github.com/nextcloud/all-in-one/blob/main/reverse-proxy.md) and [Jellyfin's networking documentation](https://jellyfin.org/docs/general/networking/#running-jellyfin-behind-a-reverse-proxy), OR use the [Caddy](https://github.com/nextcloud/all-in-one/tree/main/community-containers/caddy) community container that will automatically configure `media.$NC_DOMAIN` to redirect to your Jellyfin.

--- a/community-containers/npmplus/readme.md
+++ b/community-containers/npmplus/readme.md
@@ -3,7 +3,6 @@ This container contains a fork of the Nginx Proxy Manager, which is a WebUI for 
 
 ### Notes
 - This container is incompatible with the [caddy](https://github.com/nextcloud/all-in-one/tree/main/community-containers/caddy) community container. So make sure that you do not enable both at the same time!
-- Only works on linux since it uses network mode host
 - You can ignore the NPM configuration of the reverse-proxy.md. The NPMplus fork already contains the changes of the advanced tab.
 - Make sure that no other service is using port `443 (tcp/upd)` or `81 (tcp)` on your host as otherwise the containers will fail to start. You can check this with `sudo netstat -tulpn | grep "443\|81"` before installing AIO.
 - Please change the default login data first, after you can read inside the logs that the default config for AIO is created and there are no errors.

--- a/community-containers/plex/readme.md
+++ b/community-containers/plex/readme.md
@@ -4,7 +4,6 @@ This container bundles Plex and auto-configures it for you.
 ### Notes
 - This container is incompatible with the [Jellyfin](https://github.com/nextcloud/all-in-one/tree/main/community-containers/jellyfin) community container. So make sure that you do not enable both at the same time!
 - This is not working on arm64 since Plex does only provide x64 docker images.
-- This is not working on Docker Desktop since it needs `network_mode: host` in order to work correctly.
 - This container should usually only be run in home networks as it exposes unencrypted services like DLNA by default which can be disabld via the web interface though.
 - If you have a firewall like ufw configured, you might need to open all Plex ports in there first in order to make it work. Especially port 32400 is important!
 - After adding and starting the container, you need to visit http://ip.address.of.server:32400/manage in order to claim your server with a plex account


### PR DESCRIPTION
As it seems to be available for Docker Desktop now