### PR TITLE
Add docker in readme

### DIFF
--- a/php/README.md
+++ b/php/README.md
@@ -33,6 +33,7 @@ docker run \
 --rm \
 --name nextcloud-aio-mastercontainer \
 --volume nextcloud_aio_mastercontainer:/mnt/docker-aio-config \
+--volume /var/run/docker.sock:/var/run/docker.sock \
 nextcloud/all-in-one:latest
 ```
 


### PR DESCRIPTION
```
$ docker run \
--rm \
--name nextcloud-aio-mastercontainer \
--volume nextcloud_aio_mastercontainer:/mnt/docker-aio-config \
nextcloud/all-in-one:latest
Docker socket is not available. Cannot continue.
Please make sure to mount the docker socket into /var/run/docker.sock inside the container!
If you did this by purpose because you don't want the container to have access to the docker socket, see https://github.com/nextcloud/all-in-one/tree/main/manual-install.
```

A mistake... Sorry to create a lot of PR :sweat_smile: 