### PR TITLE
fix(pecl): configuration options in the right order

### DIFF
--- a/.github/workflows/nextcloud-update.yml
+++ b/.github/workflows/nextcloud-update.yml
@@ -25,7 +25,7 @@ jobs:
             | sort -V \
             | tail -1
         )"
-        sed -i "s|pecl install APCu.*\;|pecl install APCu-$apcu_version\;|" ./Containers/nextcloud/Dockerfile
+        sed -i "s|\(pecl install[^;]*APCu-\)[0-9.]*|\1$apcu_version|" ./Containers/nextcloud/Dockerfile
         
         # Memcached
         memcached_version="$(
@@ -36,7 +36,7 @@ jobs:
             | sort -V \
             | tail -1
         )"
-        sed -i "s|pecl install memcached.* |pecl install memcached-$memcached_version |" ./Containers/nextcloud/Dockerfile
+        sed -i "s|\(pecl install[^;]*memcached-\)[0-9.]*|\1$memcached_version|" ./Containers/nextcloud/Dockerfile
         
         # Redis
         redis_version="$(
@@ -47,18 +47,18 @@ jobs:
             | sort -V \
             | tail -1
         )"
-        sed -i "s|pecl install redis.* |pecl install redis-$redis_version |" ./Containers/nextcloud/Dockerfile
+        sed -i "s|\(pecl install[^;]*redis-\)[0-9.]*|\1$redis_version|" ./Containers/nextcloud/Dockerfile
         
         # Imagick
         imagick_version="$(
-          git ls-remote --tags https://github.com/mkoppanen/imagick.git \
+          git ls-remote --tags https://github.com/Imagick/imagick.git \
             | cut -d/ -f3 \
             | grep -viE '[a-z]' \
             | tr -d '^{}' \
             | sort -V \
             | tail -1
         )"
-        sed -i "s|pecl install imagick.*\;|pecl install imagick-$imagick_version\;|" ./Containers/nextcloud/Dockerfile
+        sed -i "s|\(pecl install[^;]*imagick-\)[0-9.]*|\1$imagick_version|" ./Containers/nextcloud/Dockerfile
 
         # Igbinary
         igbinary_version="$(
@@ -69,7 +69,7 @@ jobs:
             | sort -V \
             | tail -1
         )"
-        sed -i "s|pecl install igbinary.*\;|pecl install igbinary-$igbinary_version\;|" ./Containers/nextcloud/Dockerfile
+        sed -i "s|\(pecl install[^;]*igbinary-\)[0-9.]*|\1$igbinary_version|" ./Containers/nextcloud/Dockerfile
 
         # Nextcloud
         NC_MAJOR="$(grep "ENV NEXTCLOUD_VERSION" ./Containers/nextcloud/Dockerfile | grep -oP '[23][0-9]')"

--- a/Containers/nextcloud/Dockerfile
+++ b/Containers/nextcloud/Dockerfile
@@ -78,12 +78,10 @@ RUN set -ex; \
     ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately
-    pecl install igbinary-3.2.16; \ 
+    pecl install igbinary-3.2.16; \
     pecl install APCu-5.1.24; \
-    pecl install memcached-3.2.0 \
-        --configureoptions 'enable-memcached-igbinary="yes"'; \
-    pecl install redis-6.0.2 \
-        --configureoptions 'enable-redis-igbinary="yes" enable-redis-zstd="yes" enable-redis-lz4="yes"'; \
+    pecl install -D 'enable-memcached-igbinary="yes"' memcached-3.2.0; \
+    pecl install -D 'enable-redis-igbinary="yes" enable-redis-zstd="yes" enable-redis-lz4="yes"' redis-6.0.2; \
     pecl install imagick-3.7.0; \
     \
     docker-php-ext-enable \


### PR DESCRIPTION
This pull request addresses an issue with the PECL installation of the memcached and redis extensions.
The invocation did not properly pass the configuration options, which resulted in igbinary not being enabled for both memcached and redis.

- **old**:
![image](https://github.com/user-attachments/assets/efa5fea8-ec6e-4d90-b5ba-bcc0bd85a889)
![image](https://github.com/user-attachments/assets/c30e9c20-85d9-491d-b981-6c3f24b64cba)


- **new**:
![image](https://github.com/user-attachments/assets/034cb3e5-59fc-4a3f-aed3-bfd8e220f387)
![image](https://github.com/user-attachments/assets/09648f48-5cbb-4a35-9e44-de3e93d13cc4)
