### PR TITLE
aio-interface: invalidate cache of options-form-submit.js

### DIFF
--- a/php/templates/containers.twig
+++ b/php/templates/containers.twig
@@ -603,7 +603,7 @@
                             <p><input type="checkbox" id="whiteboard" name="whiteboard"><label for="whiteboard">Whiteboard</label></p>
                         {% endif %}
                         <input id="options-form-submit" type="submit" value="Save changes" />
-                        <script type="text/javascript" src="options-form-submit.js"></script>
+                        <script type="text/javascript" src="options-form-submit.js?v2"></script>
                     </form>
                     <p><strong>Minimal system requirements:</strong> When any optional container is enabled, at least 2GB RAM, a dual-core CPU and 40GB system storage are required. When enabling ClamAV,  Nextcloud Talk Recording-server or Fulltextsearch, at least 3GB RAM are required. For Talk Recording-server additional 2 vCPUs are required. When enabling everything, at least 5GB RAM and a quad-core CPU are required. Recommended are at least 1GB more RAM than the minimal requirement. For further advices and recommendations see <strong><a href="https://github.com/nextcloud/all-in-one/discussions/1335">this documentation</a></strong></p>
                     {% if isAnyRunning == true or is_x64_platform == false %}


### PR DESCRIPTION
Fix https://github.com/nextcloud/all-in-one/issues/5378