### PR TITLE
elastic container: ingest-attachment is now module and not a plugin

### DIFF
--- a/Containers/fulltextsearch/Dockerfile
+++ b/Containers/fulltextsearch/Dockerfile
@@ -14,8 +14,7 @@ RUN set -ex; \
     apt-get install -y --no-install-recommends \
         tzdata \
     ; \
-    rm -rf /var/lib/apt/lists/*; \
-    elasticsearch-plugin install --batch ingest-attachment
+    rm -rf /var/lib/apt/lists/*;
 
 USER 1000:0
 


### PR DESCRIPTION
When this command is executed in elastic search v8.15.3, then this warning shows up:

~~~
bin/elasticsearch-plugin install --batch ingest-attachment warning: ignoring JAVA_HOME=/opt/bitnami/java; using ES_JAVA_HOME -> Installing ingest-attachment
[ingest-attachment] is no longer a plugin but instead a module packaged with this distribution of Elasticsearch -> Please restart Elasticsearch to activate any plugins installed
~~~

The elastic website says: "The Ingest Attachment plugin is now included in Elasticsearch. See the Ingest Attachment processor."

Source: <https://www.elastic.co/guide/en/elasticsearch/plugins/current/ingest-attachment.html>

Hence, I remove the explicit installation from the elastic container image.