### PR TITLE
Update truenas scale section in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -222,45 +222,7 @@ The easiest way to run it with Portainer on Linux is to use Portainer's stacks f
 
 With the Truenas Scale Release 24.10.0 (which was officially released on October 29th 2024 as a stable release) IX Systems ditched the Kubernetes integration and implemented a fully working docker environment.
 
-One way to run Nextcloud AIO on the new Truenas Scale release is:
-- Create a dataset on your Scale instance for your docker containers / stacks (e.g. /mnt/tank/docker)
-
-- Install dockge app (Apps -> Discover Apps -> search Dockge -> Install -> In the Dockge Configuration select:
-  - Port for Dockge (standard is 5001)
-  - Hostpath folder for stacks /mnt/tank/docker
-  - Hostpath folder for dockge data /mnt/tank/docker/dockge
-    
-- Go to the Dockge Webui and create a new Stack for the AIO Mastercontainer
-
-<details>
-<summary> Click here to expand</summary>
-    
-```    
-services:
-  nextcloud:
-    image: nextcloud/all-in-one:latest # Must be changed to 'nextcloud/all-in-one:latest-arm64' when used with an arm64 CPU
-    restart: always
-    container_name: nextcloud-aio-mastercontainer
-    volumes:
-      - nextcloud_aio_mastercontainer:/mnt/docker-aio-config
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-    ports:
-      - 8080:8080
-    environment:
-      # Is needed when using any of the options below
-      - APACHE_PORT=11000 # Is needed when running behind a reverse proxy. See https://github.com/nextcloud/all-in-one/blob/main/reverse-proxy.md
-      - NEXTCLOUD_DATADIR=/mnt/tank/docker/nextcloud_aio/data # Allows to set the host directory for Nextcloud's datadir. See https://github.com/nextcloud/all-in-one#how-to-change-the-default-location-of-nextclouds-datadir
-      - NEXTCLOUD_MOUNT=/mnt/tank/docker/nextcloud_aio # Allows the Nextcloud container to access the chosen directory on the host. See https://github.com/nextcloud/all-in-one#how-to-allow-the-nextcloud-container-to-access-directories-on-the-host
-      - NEXTCLOUD_MEMORY_LIMIT=4096M
-networks: {}
-
-volumes:
-  nextcloud_aio_mastercontainer:
-    name: nextcloud_aio_mastercontainer
-```    
-</details>
-
-- Deploy the Stack and Nextcloud AIO is running on your Truenas Scale
+For a more complete guide, see this guide by @zybster: https://github.com/nextcloud/all-in-one/discussions/5506
 
 On older TrueNAS SCALE releases with Kubernetes environment, there are two ways to run AIO. The preferred one is to run AIO inside a VM. This is necessary since they do not expose the docker socket for containers on the host, you also cannot use docker-compose on it thus and it is also not possible to run custom helm-charts that are not explicitly written for TrueNAS SCALE.
 

--- a/readme.md
+++ b/readme.md
@@ -219,7 +219,50 @@ If you have the NAS setup on your local network (which is most often the case) y
 The easiest way to run it with Portainer on Linux is to use Portainer's stacks feature and use [this docker-compose file](./compose.yaml) in order to start AIO correctly. 
 
 ### Can I run AIO on TrueNAS SCALE?
-On TrueNAS SCALE, there are two ways to run AIO. The preferred one is to run AIO inside a VM. This is necessary since they do not expose the docker socket for containers on the host, you also cannot use docker-compose on it thus and it is also not possible to run custom helm-charts that are not explicitly written for TrueNAS SCALE.
+
+With the Truenas Scale Release 24.10.0 (which was officially released on October 29th 2024 as a stable release) IX Systems ditched the Kubernetes integration and implemented a fully working docker environment.
+
+One way to run Nextcloud AIO on the new Truenas Scale release is:
+- Create a dataset on your Scale instance for your docker containers / stacks (e.g. /mnt/tank/docker)
+
+- Install dockge app (Apps -> Discover Apps -> search Dockge -> Install -> In the Dockge Configuration select:
+  - Port for Dockge (standard is 5001)
+  - Hostpath folder for stacks /mnt/tank/docker
+  - Hostpath folder for dockge data /mnt/tank/docker/dockge
+    
+- Go to the Dockge Webui and create a new Stack for the AIO Mastercontainer
+
+<details>
+<summary> Click here to expand</summary>
+    
+```    
+services:
+  nextcloud:
+    image: nextcloud/all-in-one:latest # Must be changed to 'nextcloud/all-in-one:latest-arm64' when used with an arm64 CPU
+    restart: always
+    container_name: nextcloud-aio-mastercontainer
+    volumes:
+      - nextcloud_aio_mastercontainer:/mnt/docker-aio-config
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    ports:
+      - 8080:8080
+    environment:
+      # Is needed when using any of the options below
+      - APACHE_PORT=11000 # Is needed when running behind a reverse proxy. See https://github.com/nextcloud/all-in-one/blob/main/reverse-proxy.md
+      - NEXTCLOUD_DATADIR=/mnt/tank/docker/nextcloud_aio/data # Allows to set the host directory for Nextcloud's datadir. See https://github.com/nextcloud/all-in-one#how-to-change-the-default-location-of-nextclouds-datadir
+      - NEXTCLOUD_MOUNT=/mnt/tank/docker/nextcloud_aio # Allows the Nextcloud container to access the chosen directory on the host. See https://github.com/nextcloud/all-in-one#how-to-allow-the-nextcloud-container-to-access-directories-on-the-host
+      - NEXTCLOUD_MEMORY_LIMIT=4096M
+networks: {}
+
+volumes:
+  nextcloud_aio_mastercontainer:
+    name: nextcloud_aio_mastercontainer
+```    
+</details>
+
+- Deploy the Stack and Nextcloud AIO is running on your Truenas Scale
+
+On older TrueNAS SCALE releases with Kubernetes environment, there are two ways to run AIO. The preferred one is to run AIO inside a VM. This is necessary since they do not expose the docker socket for containers on the host, you also cannot use docker-compose on it thus and it is also not possible to run custom helm-charts that are not explicitly written for TrueNAS SCALE.
 
 Another but untested way is to install Portainer on your TrueNAS SCALE from here https://truecharts.org/charts/stable/portainer/installation-notes and add the Helm-chart repository https://nextcloud.github.io/all-in-one/ into Portainer by following https://docs.portainer.io/user/kubernetes/helm. More docs on AIOs Helm Chart are available here: https://github.com/nextcloud/all-in-one/tree/main/nextcloud-aio-helm-chart#nextcloud-aio-helm-chart.
 


### PR DESCRIPTION
Since IX System ditched Kubernetes and integrated a full-fledged docker environment in Truenas Scale 24.10.0 (Electric Eel) it is now very easy to install Nextcloud AIO on Scale On way is listed here.