### PR TITLE
talk-recording: change to firefox-esr

### DIFF
--- a/Containers/talk-recording/Dockerfile
+++ b/Containers/talk-recording/Dockerfile
@@ -17,7 +17,7 @@ RUN set -ex; \
         bash \
         xvfb \
         ffmpeg \
-        firefox \
+        firefox-esr \
         bind-tools \
         netcat-openbsd \
         git \


### PR DESCRIPTION
to prevent `WARNING:selenium.webdriver.common.selenium_manager:The geckodriver version (0.34.0) detected in PATH at /usr/bin/geckodriver might not be compatible with the detected firefox version (132.0); currently, geckodriver 0.35.0 is recommended for firefox 132.*, so it is advised to delete the driver in PATH and retry`