### PR TITLE
Connect mastercontainer to docker network specified by APACHE_ADDITIONAL_NETWORK

### DIFF
--- a/Containers/mastercontainer/start.sh
+++ b/Containers/mastercontainer/start.sh
@@ -200,9 +200,9 @@ It needs to be a string with letters, numbers, hyphens and underscores.
 It is set to '$APACHE_ADDITIONAL_NETWORK'."
         exit 1
     fi
-    tmp_out=$(sudo -u www-data docker network connect $APACHE_ADDITIONAL_NETWORK nextcloud-aio-mastercontainer 2>&1)
-    if [ -n "$tmp_out" ] && [[ ! "$tmp_out" =~ "nextcloud-aio-mastercontainer already exists in network $APACHE_ADDITIONAL_NETWORK" ]]; then
-        print_red "Unable to connect to $APACHE_ADDITIONAL_NETWORK. Cannot continue. Error: \n $tmp_out"
+    tmp_out=$(sudo -u www-data docker network connect "$APACHE_ADDITIONAL_NETWORK" nextcloud-aio-mastercontainer 2>&1)
+    if [ "$?" -ne 0 ] && [[ ! "$tmp_out" == *"nextcloud-aio-mastercontainer already exists in network $APACHE_ADDITIONAL_NETWORK"* ]]; then
+        print_red "Unable to connect to $APACHE_ADDITIONAL_NETWORK. Cannot continue. Error: $tmp_out"
         exit 1
     fi
 fi

--- a/Containers/mastercontainer/start.sh
+++ b/Containers/mastercontainer/start.sh
@@ -200,10 +200,11 @@ It needs to be a string with letters, numbers, hyphens and underscores.
 It is set to '$APACHE_ADDITIONAL_NETWORK'."
         exit 1
     fi
-    tmp_out=$(sudo -u www-data docker network connect "$APACHE_ADDITIONAL_NETWORK" nextcloud-aio-mastercontainer 2>&1)
-    if [ "$?" -ne 0 ] && [[ ! "$tmp_out" == *"nextcloud-aio-mastercontainer already exists in network $APACHE_ADDITIONAL_NETWORK"* ]]; then
-        print_red "Unable to connect to $APACHE_ADDITIONAL_NETWORK. Cannot continue. Error: $tmp_out"
-        exit 1
+    if ! tmp_out=$(sudo -u www-data docker network connect "$APACHE_ADDITIONAL_NETWORK" nextcloud-aio-mastercontainer 2>&1); then
+        if [[ ! "$tmp_out" == *"nextcloud-aio-mastercontainer already exists in network $APACHE_ADDITIONAL_NETWORK"* ]]; then
+            print_red "Unable to connect to $APACHE_ADDITIONAL_NETWORK, cannot continue. Error: $tmp_out"
+            exit 1
+	fi
     fi
 fi
 if [ -n "$TALK_PORT" ]; then

--- a/Containers/mastercontainer/start.sh
+++ b/Containers/mastercontainer/start.sh
@@ -200,6 +200,11 @@ It needs to be a string with letters, numbers, hyphens and underscores.
 It is set to '$APACHE_ADDITIONAL_NETWORK'."
         exit 1
     fi
+    tmp_out=$(sudo -u www-data docker network connect $APACHE_ADDITIONAL_NETWORK nextcloud-aio-mastercontainer 2>&1)
+    if [ -n "$tmp_out" ] && [[ ! "$tmp_out" =~ "nextcloud-aio-mastercontainer already exists in network $APACHE_ADDITIONAL_NETWORK" ]]; then
+        print_red "Unable to connect to $APACHE_ADDITIONAL_NETWORK. Cannot continue. Error: \n $tmp_out"
+        exit 1
+    fi
 fi
 if [ -n "$TALK_PORT" ]; then
     if ! check_if_number "$TALK_PORT"; then

--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -899,6 +899,11 @@ readonly class DockerActionManager {
         $this->ConnectContainerIdToNetwork('nextcloud-aio-mastercontainer', '');
         // Don't disconnect here since it slows down the initial login by a lot. Is getting done during cron.sh instead.
         // $this->DisconnectContainerFromBridgeNetwork('nextcloud-aio-mastercontainer');
+
+        $apacheAdditionalNetwork = $this->configurationManager->GetApacheAdditionalNetwork();
+        if ($apacheAdditionalNetwork !== '') {
+            $this->ConnectContainerIdToNetwork('nextcloud-aio-mastercontainer', '', $apacheAdditionalNetwork, false);
+        }
     }
 
     public function ConnectContainerToNetwork(Container $container) : void


### PR DESCRIPTION
This is an extension of https://github.com/nextcloud/all-in-one/pull/5484 to allow for `mastercontainer`'s admin page to also be behind a reverse proxy (for security, authentication etc.) instead of just an unsecured localhost port. For example, I've my reverse proxy set up to point `https://aio-nextcloud.mydomain.com` to `https://nextcloud-aio-mastercontainer:8080` for the admin page.

Since the user is specifying `APACHE_ADDITIONAL_NETWORK` as a means to connect the reverse proxy, it is natural to use the same information for mastercontainer's reverse proxy setup as well. Yes in theory, the user can create this connection by docker commands or docker compose file (I do this today), but then the user must specify not just the network for proxy but also create `nextcloud-aio` doing something like below:
```
services:
  nextcloud-aio-mastercontainer:
    image: nextcloud/all-in-one:latest
...
    networks:
      - nextcloud-aio 
      - front_net

networks:
  front_net:
    external: true
  nextcloud-aio:
    name: nextcloud-aio
    driver: bridge
```
This isn't easy or obvious for newcomer, and it'd be much more seamless if handled automatically. FWIW, there's some precedence for mastercontainer manipulating its own network -- the default compose.yml suggests `network_mode: bridge`, then mastercontainer connects itself to `nextcloud-aio` and then later disconnects itself from the bridge through a cron job. Since we're manipulating the network, it's a relatively incremental extension to connect mastercontainer with reverse proxy with minimal downsides. 
And the `start.sh` change also has the nice side-benefit of doing an early error check with clear error message if the specified network has issues.

After this change, I imagine the end-user flow to be:
1. User sets up some reverse proxy container with SSL in a docker container. Eg: Nginx Proxy Manager with let's encrypt + DuckDNS is extremely simple GUI based and amateur proof. There's at least 3-4 tutorials I've seen on internet which are straight forward to follow. And potentially authentication schemes as well.
1. User sets up 2 different routes:
    - Some aio URL (eg: `https://aio-nextcloud.mydomain.com`) pointing to `https://nextcloud-aio-mastercontainer:8080` for the admin page.
    - Main nextcloud URL (eg: `https://nextcloud.mydomain.com`) pointing to `http://nextcloud-aio-apache:11000`.
1. User launches the Nextcloud AIO with default compose file and specifies `APACHE_ADDITIONAL_NETWORK=<the network name of reverse proxy>`.
1. Follow all the steps in GUI, and because reverse proxy is already set up, everything including domaincheck just works.

(FWIW, I do intend to post this as a guide somewhere after this pull request goes through.) 