### PR TITLE
borgbackup: make logs a bit cleaner if local archive is used

### DIFF
--- a/Containers/borgbackup/backupscript.sh
+++ b/Containers/borgbackup/backupscript.sh
@@ -66,7 +66,9 @@ if [ -n "$BORG_REMOTE_REPO" ] && ! [ -f "$BORGBACKUP_KEY" ]; then
     ssh-keygen  -f "$BORGBACKUP_KEY" -N ""
     echo "You should configure the remote to accept this public key"
 fi
-echo "Your public ssh key for borgbackup is: $(cat "$BORGBACKUP_KEY.pub")"
+if [ -n "$BORG_REMOTE_REPO" ]
+    echo "Your public ssh key for borgbackup is: $(cat "$BORGBACKUP_KEY.pub")"
+fi
 
 # Do the backup
 if [ "$BORG_MODE" = backup ]; then

--- a/Containers/borgbackup/backupscript.sh
+++ b/Containers/borgbackup/backupscript.sh
@@ -66,7 +66,7 @@ if [ -n "$BORG_REMOTE_REPO" ] && ! [ -f "$BORGBACKUP_KEY" ]; then
     ssh-keygen  -f "$BORGBACKUP_KEY" -N ""
     echo "You should configure the remote to accept this public key"
 fi
-if [ -n "$BORG_REMOTE_REPO" ]
+if [ -n "$BORG_REMOTE_REPO" ] && [ -f "$BORGBACKUP_KEY.pub" ]; then
     echo "Your public ssh key for borgbackup is: $(cat "$BORGBACKUP_KEY.pub")"
 fi
 


### PR DESCRIPTION
Follow-up to https://github.com/nextcloud/all-in-one/pull/4804

Prevent logs like the following when used with local archive:
```
cat: can't open '.pub': No such file or directory
Your public ssh key for borgbackup is: 
```