### PR TITLE
Correctly disable some supervisord logs

### DIFF
--- a/Containers/apache/supervisord.conf
+++ b/Containers/apache/supervisord.conf
@@ -9,8 +9,8 @@ logfile_backups=10
 loglevel=error
 
 [program:apache]
-# stdout_logfile=/dev/stdout
-# stdout_logfile_maxbytes=0
+# Stdout logging is disabled as otherwise the logs are spammed
+stdout_logfile=NONE
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 command=apachectl -DFOREGROUND

--- a/Containers/mastercontainer/supervisord.conf
+++ b/Containers/mastercontainer/supervisord.conf
@@ -9,16 +9,16 @@ loglevel=error
 user=root
 
 [program:php-fpm]
-# stdout_logfile=/dev/stdout
-# stdout_logfile_maxbytes=0
+# Stdout logging is disabled as otherwise the logs are spammed
+stdout_logfile=NONE
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 command=php-fpm
 user=root
 
 [program:apache]
-# stdout_logfile=/dev/stdout
-# stdout_logfile_maxbytes=0
+# Stdout logging is disabled as otherwise the logs are spammed
+stdout_logfile=NONE
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 command=httpd -DFOREGROUND

--- a/Containers/mastercontainer/supervisord.conf
+++ b/Containers/mastercontainer/supervisord.conf
@@ -58,9 +58,7 @@ user=root
 
 [program:domain-validator]
 # Logging is disabled as otherwise all attempts will be logged which spams the logs
-# stdout_logfile=/dev/stdout
-# stdout_logfile_maxbytes=0
-# stderr_logfile=/dev/stderr
-# stderr_logfile_maxbytes=0
+stdout_logfile=NONE
+stderr_logfile=NONE
 command=php -S 127.0.0.1:9876 /var/www/docker-aio/php/domain-validator.php
 user=www-data


### PR DESCRIPTION
Explicitly use NONE value for stdout_logfile and stderr_logfile to disable domain-validator logs.

Accoring to supervisord documentation (http://supervisord.org/configuration.html#program-x-section-values), if stdout_logfile/stderr_logfile is unset or set to AUTO, supervisor will automatically choose a pseudo random file location. If this is set to NONE, supervisord will create no log file.

Without this change, suppervisord creates a logfile which is updated every minute:
```
tail -f /data/docker/overlay2/a9dd93b0ebe8734925e6230d7528b1d3a67f66973cfbded16ad6e9398c36608c/diff/var/log/supervisord/domain-validator-stderr---supervisor-qrmls8ox.log 
[Fri Nov  8 22:17:53 2024] 127.0.0.1:42558 Closing
[Fri Nov  8 22:18:23 2024] 127.0.0.1:52348 Accepted
[Fri Nov  8 22:18:23 2024] 127.0.0.1:52348 Closed without sending a request; it was probably just an unused speculative preconnection
[Fri Nov  8 22:18:23 2024] 127.0.0.1:52348 Closing
[Fri Nov  8 22:18:54 2024] 127.0.0.1:40940 Accepted
[Fri Nov  8 22:18:54 2024] 127.0.0.1:40940 Closed without sending a request; it was probably just an unused speculative preconnection
[Fri Nov  8 22:18:54 2024] 127.0.0.1:40940 Closing
[Fri Nov  8 22:19:24 2024] 127.0.0.1:45126 Accepted
[Fri Nov  8 22:19:24 2024] 127.0.0.1:45126 Closed without sending a request; it was probably just an unused speculative preconnection
[Fri Nov  8 22:19:24 2024] 127.0.0.1:45126 Closing
```