### PR TITLE
build(nextcloud): bump php to 8.3

### DIFF
--- a/.github/workflows/nextcloud-update.yml
+++ b/.github/workflows/nextcloud-update.yml
@@ -51,7 +51,7 @@ jobs:
         
         # Imagick
         imagick_version="$(
-          git ls-remote --tags https://github.com/Imagick/imagick.git \
+          git ls-remote --tags https://github.com/imagick/imagick.git \
             | cut -d/ -f3 \
             | grep -viE '[a-z]' \
             | tr -d '^{}' \
@@ -59,6 +59,12 @@ jobs:
             | tail -1
         )"
         sed -i "s|\(pecl install[^;]*imagick-\)[0-9.]*|\1$imagick_version|" ./Containers/nextcloud/Dockerfile
+
+        # Imagick git-commit-hash from HEAD
+        imagick_commit_hash="$(
+          git ls-remote https://github.com/imagick/imagick.git HEAD | awk '{print $1}'
+        )"
+        sed -i "s/\(ARG IMAGICK_COMMIT_HASH=\)[a-fA-F0-9]*$/\1$imagick_commit_hash/" ./Containers/nextcloud/Dockerfile
 
         # Igbinary
         igbinary_version="$(

--- a/Containers/nextcloud/Dockerfile
+++ b/Containers/nextcloud/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:latest
-FROM php:8.2.25-fpm-alpine3.20
+FROM php:8.3.13-fpm-alpine3.20
 
 ENV PHP_MEMORY_LIMIT=512M
 ENV PHP_UPLOAD_LIMIT=10G
@@ -78,17 +78,18 @@ RUN set -ex; \
     ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately
-    pecl install igbinary-3.2.16; \
+    pecl install -o igbinary-3.2.16; \
     pecl install APCu-5.1.24; \
     pecl install -D 'enable-memcached-igbinary="yes"' memcached-3.3.0; \
-    pecl install -D 'enable-redis-igbinary="yes" enable-redis-zstd="yes" enable-redis-lz4="yes"' redis-6.1.0; \
-    pecl install imagick-3.7.0; \
+    pecl install -oD 'enable-redis-igbinary="yes" enable-redis-zstd="yes" enable-redis-lz4="yes"' redis-6.1.0; \
+    pecl install -o imagick-3.7.0; \
     \
     docker-php-ext-enable \
         igbinary \
         apcu \
         memcached \
         redis \
+        imagick \
     ; \
     rm -r /tmp/pear; \
     \

--- a/Containers/nextcloud/Dockerfile
+++ b/Containers/nextcloud/Dockerfile
@@ -13,6 +13,9 @@ ENV AIO_TOKEN=123456
 ENV AIO_URL=localhost
 # AIO settings end # Do not remove or change this line!
 
+# Define the commit hash for imagick as a variable
+ARG IMAGICK_COMMIT_HASH=28f27044e435a2b203e32675e942eb8de620ee58
+
 COPY --chmod=775 *.sh /
 COPY --chmod=774 upgrade.exclude /upgrade.exclude
 COPY config/*.php /
@@ -82,7 +85,20 @@ RUN set -ex; \
     pecl install APCu-5.1.24; \
     pecl install -D 'enable-memcached-igbinary="yes"' memcached-3.3.0; \
     pecl install -oD 'enable-redis-igbinary="yes" enable-redis-zstd="yes" enable-redis-lz4="yes"' redis-6.1.0; \
-    pecl install -o imagick-3.7.0; \
+#    pecl install -o imagick-3.7.0; \
+# Begin workaround ->
+# The master version on the imagick repository is compatible with PHP 8.3. However, the PECL version is not updated yet.
+# As soon as it will get updated, we can switch back to the PECL version, instead of having this workaround.
+    apk add --no-cache --virtual .git-build-deps git \
+    && git clone https://github.com/imagick/imagick.git --depth 1 /tmp/imagick \
+    && cd /tmp/imagick \
+    && git fetch --depth 1 origin ${IMAGICK_COMMIT_HASH} \
+    && git checkout ${IMAGICK_COMMIT_HASH} \
+    && sed -i "s/@PACKAGE_VERSION@/git-${IMAGICK_COMMIT_HASH:0:7}/" php_imagick.h \
+    && phpize && ./configure && make && make install; \
+    apk del .git-build-deps; \
+    cd && rm -r /tmp/imagick; \
+# <- End workaround
     \
     docker-php-ext-enable \
         igbinary \


### PR DESCRIPTION
- bump php to 8.3.13-fpm-alpine3.2
- workaround to build php-imagick module

Close https://github.com/nextcloud/all-in-one/issues/3890