### PR TITLE
Allow collabora to escalate privillege.

### DIFF
--- a/nextcloud-aio-helm-chart/templates/nextcloud-aio-collabora-deployment.yaml
+++ b/nextcloud-aio-helm-chart/templates/nextcloud-aio-collabora-deployment.yaml
@@ -42,7 +42,7 @@ spec:
             - containerPort: 9980
               protocol: TCP
           securityContext:
-            allowPrivilegeEscalation: false
+            allowPrivilegeEscalation: true
             runAsNonRoot: true
             capabilities:
               add:


### PR DESCRIPTION
Without allowing this, collabora cannot fork the process and complains with the following in logs:
```
wsd-00001-00001 2024-11-20 00:31:26.654865 -0500 [ coolwsd ] INF  Waiting for a new child for a max of 20000ms| wsd/COOLWSD.cpp:4433
```

This is extensively discussed on Collabora [in this issue](https://github.com/CollaboraOnline/online/issues/9948).

However, it is possible that Nextcloud's build of collabora did not incoporate [the change yet](https://github.com/CollaboraOnline/online/pull/9961/commits), in [this file](https://github.com/CollaboraOnline/online/blob/master/debian/coolwsd-deprecated.postinst).

The issue mentioned that it is not ideal to run in privileged, but Collabora could not run otherwise in my Debian K8s cluster.

Can the NC engineers verify that the nextcloud-aio/collabora:latest build did incorporate that change? Because if not, then we will need to enable this escalation.