### PR TITLE
docker-socket-proxy: allowed read/write/exec of files for AppAPI for ExApps containers 

### DIFF
--- a/Containers/docker-socket-proxy/haproxy.cfg
+++ b/Containers/docker-socket-proxy/haproxy.cfg
@@ -22,7 +22,12 @@ frontend http
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/nc_app_[a-zA-Z0-9_.-]+/((start)|(stop)) } METH_POST
     # container rm: DELETE containers/%s
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/nc_app_[a-zA-Z0-9_.-]+ } METH_DELETE
-
+    # container update/exec: POST containers/%s/update containers/%s/exec
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/nc_app_[a-zA-Z0-9_.-]+/((update)|(exec)) } METH_POST
+    # container put: PUT containers/%s/archive
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/nc_app_[a-zA-Z0-9_.-]+/archive } METH_PUT
+    # run exec instance: POST exec/%s
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/exec/[a-zA-Z0-9_.-]+/start } METH_POST
 
     # container create: POST containers/create?name=%s
     # ACL to restrict container name to nc_app_[a-zA-Z0-9_.-]+


### PR DESCRIPTION
Required for https://github.com/nextcloud/app_api/pull/448 for the upcoming Nextcloud 31 release.
Changes are the same as here: https://github.com/nextcloud/docker-socket-proxy/pull/41

In brief:

  * `PUT containers/%s/archive` allows AppAPI to write files to the ExApp container. 
  * `POST containers/%s/update` will allows to change ContainerRestart policy in future. [Docker API](https://docs.docker.com/reference/api/engine/version/v1.47/#tag/Container/operation/ContainerUpdate)
  * `POST containers/%s/exec` is used to create execution object.
  * `POST exec/%s` allows to start execution object.
  
First three endpoints is limited to with usual secure mask `nc_app_[a-zA-Z0-9_.-]+` to allow access only to ExApps.
  
