### PR TITLE
Revert "manual-install: add back the nextcloud-aio network"

### DIFF
--- a/manual-install/latest.yml
+++ b/manual-install/latest.yml
@@ -42,8 +42,6 @@ services:
       - nextcloud_aio_nextcloud:/var/www/html:ro
       - nextcloud_aio_apache:/mnt/data:rw
     restart: unless-stopped
-    networks:
-      - nextcloud-aio
     read_only: true
     tmpfs:
       - /var/log/supervisord
@@ -72,8 +70,6 @@ services:
     stop_grace_period: 1800s
     restart: unless-stopped
     shm_size: 268435456
-    networks:
-      - nextcloud-aio
     read_only: true
     tmpfs:
       - /var/run/postgresql
@@ -162,8 +158,6 @@ services:
       - WHITEBOARD_ENABLED
     stop_grace_period: 600s
     restart: unless-stopped
-    networks:
-      - nextcloud-aio
     cap_drop:
       - NET_RAW
 
@@ -186,8 +180,6 @@ services:
       - POSTGRES_DB=nextcloud_database
       - POSTGRES_USER=nextcloud
     restart: unless-stopped
-    networks:
-      - nextcloud-aio
     read_only: true
     cap_drop:
       - NET_RAW
@@ -204,8 +196,6 @@ services:
     volumes:
       - nextcloud_aio_redis:/data:rw
     restart: unless-stopped
-    networks:
-      - nextcloud-aio
     read_only: true
     cap_drop:
       - NET_RAW
@@ -225,8 +215,6 @@ services:
     restart: unless-stopped
     profiles:
       - collabora
-    networks:
-      - nextcloud-aio
     cap_add:
       - MKNOD
       - SYS_ADMIN
@@ -254,8 +242,6 @@ services:
     profiles:
       - talk
       - talk-recording
-    networks:
-      - nextcloud-aio
     read_only: true
     tmpfs:
       - /var/log/supervisord
@@ -283,8 +269,6 @@ services:
     restart: unless-stopped
     profiles:
       - talk-recording
-    networks:
-      - nextcloud-aio
     read_only: true
     tmpfs:
       - /conf
@@ -306,8 +290,6 @@ services:
     restart: unless-stopped
     profiles:
       - clamav
-    networks:
-      - nextcloud-aio
     read_only: true
     tmpfs:
       - /var/lock
@@ -331,8 +313,6 @@ services:
     restart: unless-stopped
     profiles:
       - onlyoffice
-    networks:
-      - nextcloud-aio
     cap_drop:
       - NET_RAW
 
@@ -352,8 +332,6 @@ services:
       - NET_RAW
     profiles:
       - imaginary
-    networks:
-      - nextcloud-aio
     read_only: true
     tmpfs:
       - /tmp
@@ -379,8 +357,6 @@ services:
     restart: unless-stopped
     profiles:
       - fulltextsearch
-    networks:
-      - nextcloud-aio
     cap_drop:
       - NET_RAW
 
@@ -401,8 +377,6 @@ services:
     profiles:
       - whiteboard
     read_only: true
-    networks:
-      - nextcloud-aio
     cap_drop:
       - NET_RAW
 
@@ -429,5 +403,5 @@ volumes:
     name: nextcloud_aio_nextcloud_data
 
 networks:
-  nextcloud-aio:
-    name: nextcloud-aio
+  default:
+    driver: bridge

--- a/manual-install/update-yaml.sh
+++ b/manual-install/update-yaml.sh
@@ -18,6 +18,7 @@ OUTPUT="$(echo "$OUTPUT" | jq 'del(.services[].devices)')"
 OUTPUT="$(echo "$OUTPUT" | jq 'del(.services[].backup_volumes)')"
 OUTPUT="$(echo "$OUTPUT" | jq 'del(.services[].nextcloud_exec_commands)')"
 OUTPUT="$(echo "$OUTPUT" | jq 'del(.services[].image_tag)')"
+OUTPUT="$(echo "$OUTPUT" | jq 'del(.services[].networks)')"
 OUTPUT="$(echo "$OUTPUT" | jq 'del(.services[].documentation)')"
 OUTPUT="$(echo "$OUTPUT" | jq 'del(.services[] | select(.container_name == "nextcloud-aio-watchtower"))')"
 OUTPUT="$(echo "$OUTPUT" | jq 'del(.services[] | select(.container_name == "nextcloud-aio-domaincheck"))')"
@@ -140,8 +141,8 @@ done
 cat << NETWORK >> containers.yml
 
 networks:
-  nextcloud-aio:
-    name: nextcloud-aio
+  default:
+    driver: bridge
 NETWORK
 
 mv containers.yml latest.yml


### PR DESCRIPTION
Reverts nextcloud/all-in-one#5666

This is not the correct fix. The correct fix lies somewhere here:
https://github.com/nextcloud/all-in-one/blob/6e2a14f1c7ef936a06612dbfb747b08dd6505724/Containers/nextcloud/entrypoint.sh#L596-L600