### PR TITLE
talk: update Janus to 1.x

### DIFF
--- a/.github/workflows/talk.yml
+++ b/.github/workflows/talk.yml
@@ -36,7 +36,7 @@ jobs:
         
         # Janus
         janus_version="$(
-          git ls-remote https://github.com/meetecho/janus-gateway v0.*.* \
+          git ls-remote https://github.com/meetecho/janus-gateway v1.*.* \
             | cut -d/ -f3 \
             | sort -V \
             | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" \

--- a/Containers/talk/Dockerfile
+++ b/Containers/talk/Dockerfile
@@ -4,7 +4,7 @@ FROM eturnal/eturnal:1.12.1 AS eturnal
 FROM strukturag/nextcloud-spreed-signaling:2.0.1 AS signaling
 FROM alpine:3.20.3 AS janus
 
-ARG JANUS_VERSION=v0.15.0
+ARG JANUS_VERSION=v1.3.0
 WORKDIR /src
 RUN set -ex; \
     apk add --no-cache \


### PR DESCRIPTION
Was done upstream quite a while ago already: https://github.com/strukturag/nextcloud-spreed-signaling/pull/749
So I hope it works - however will of course also do some manual testing on it.