### PR TITLE
Add dot to network regex check

### DIFF
--- a/Containers/mastercontainer/start.sh
+++ b/Containers/mastercontainer/start.sh
@@ -194,7 +194,7 @@ It is set to '$APACHE_IP_BINDING'."
     fi
 fi
 if [ -n "$APACHE_ADDITIONAL_NETWORK" ]; then
-    if ! echo "$APACHE_ADDITIONAL_NETWORK" | grep -q "^[a-zA-Z0-9_-]\+$"; then
+    if ! echo "$APACHE_ADDITIONAL_NETWORK" | grep -q "^[a-zA-Z0-9._-]\+$"; then
         print_red "You've set APACHE_ADDITIONAL_NETWORK but not to an allowed value.
 It needs to be a string with letters, numbers, hyphens and underscores.
 It is set to '$APACHE_ADDITIONAL_NETWORK'."


### PR DESCRIPTION
In Unraid, vlans get a naming convention containing dots. Example `br0.3`. If my reverse proxy is on a vlan, I cannot use the same network for nextcloud-aio because of this check. 