### PR TITLE
Improve nginx reverse proxy template

### DIFF
--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -362,6 +362,14 @@ server {
     # quic_retry on;                            # uncomment to enable HTTP/3 / QUIC - supported on nginx v1.25.0+
     # add_header Alt-Svc 'h3=":443"; ma=86400'; # uncomment to enable HTTP/3 / QUIC - supported on nginx v1.25.0+
 
+    proxy_buffering off;
+    proxy_request_buffering off;
+
+    client_max_body_size 0;
+    client_body_buffer_size 1m;
+    http3_stream_buffer_size 1m;
+    proxy_read_timeout 86400s;
+
     server_name <your-nc-domain>;
 
     location / {
@@ -374,11 +382,6 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Host $host;
         proxy_set_header Early-Data $ssl_early_data;
-
-        proxy_buffering off;
-        proxy_request_buffering off;
-        proxy_read_timeout 86400s;
-        client_max_body_size 0;
 
         # Websocket
         proxy_http_version 1.1;
@@ -434,7 +437,7 @@ Second, see these screenshots for a working config:
 ![grafik](https://user-images.githubusercontent.com/75573284/213889746-87dbe8c5-4d1f-492f-b251-bbf82f1510d0.png)
 
 ```
-client_body_buffer_size 512k;
+client_body_buffer_size 1m;
 proxy_read_timeout 86400s;
 client_max_body_size 0;
 ```

--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -360,7 +360,7 @@ server {
     # http3 on;                                 # uncomment to enable HTTP/3 / QUIC - supported on nginx v1.25.0+
     # quic_gso on;                              # uncomment to enable HTTP/3 / QUIC - supported on nginx v1.25.0+
     # quic_retry on;                            # uncomment to enable HTTP/3 / QUIC - supported on nginx v1.25.0+
-    # quic_bpf on;                              # improves  HTTP/3 / QUIC - supported on nginx v1.25.0+, if nginx runs as a docker container you need to give it privileged permission
+    # quic_bpf on;                              # improves  HTTP/3 / QUIC - supported on nginx v1.25.0+, if nginx runs as a docker container you need to give it privileged permission to use this option
     # add_header Alt-Svc 'h3=":443"; ma=86400'; # uncomment to enable HTTP/3 / QUIC - supported on nginx v1.25.0+
 
     proxy_buffering off;

--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -358,6 +358,7 @@ server {
     # listen 443 quic reuseport;       # uncomment to enable HTTP/3 / QUIC - supported on nginx v1.25.0+ - please remove "reuseport" if there is already another quic listener on port 443 with enabled reuseport
     # listen [::]:443 quic reuseport;  # uncomment to enable HTTP/3 / QUIC - supported on nginx v1.25.0+ - please remove "reuseport" if there is already another quic listener on port 443 with enabled reuseport - keep comment to disable IPv6
     # http3 on;                                 # uncomment to enable HTTP/3 / QUIC - supported on nginx v1.25.0+
+    # quic_gso on;                              # uncomment to enable HTTP/3 / QUIC - supported on nginx v1.25.0+
     # quic_retry on;                            # uncomment to enable HTTP/3 / QUIC - supported on nginx v1.25.0+
     # add_header Alt-Svc 'h3=":443"; ma=86400'; # uncomment to enable HTTP/3 / QUIC - supported on nginx v1.25.0+
 
@@ -373,7 +374,8 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Host $host;
         proxy_set_header Early-Data $ssl_early_data;
-    
+
+        proxy_buffering off;
         proxy_request_buffering off;
         proxy_read_timeout 86400s;
         client_max_body_size 0;

--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -360,6 +360,7 @@ server {
     # http3 on;                                 # uncomment to enable HTTP/3 / QUIC - supported on nginx v1.25.0+
     # quic_gso on;                              # uncomment to enable HTTP/3 / QUIC - supported on nginx v1.25.0+
     # quic_retry on;                            # uncomment to enable HTTP/3 / QUIC - supported on nginx v1.25.0+
+    # quic_bpf on;                              # improves  HTTP/3 / QUIC - supported on nginx v1.25.0+, if nginx runs as a docker container you need to give it privileged permission
     # add_header Alt-Svc 'h3=":443"; ma=86400'; # uncomment to enable HTTP/3 / QUIC - supported on nginx v1.25.0+
 
     proxy_buffering off;
@@ -406,7 +407,7 @@ server {
 
     ssl_prefer_server_ciphers on;
     ssl_conf_command Options PrioritizeChaCha;
-    ssl_ciphers TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256;
+    ssl_ciphers TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-GCM-SHA256;
 }
 
 ```

--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -367,8 +367,8 @@ server {
     proxy_request_buffering off;
 
     client_max_body_size 0;
-    client_body_buffer_size 1m;
-    http3_stream_buffer_size 1m;
+    client_body_buffer_size 512k;
+    http3_stream_buffer_size 512k;
     proxy_read_timeout 86400s;
 
     server_name <your-nc-domain>;
@@ -438,7 +438,7 @@ Second, see these screenshots for a working config:
 ![grafik](https://user-images.githubusercontent.com/75573284/213889746-87dbe8c5-4d1f-492f-b251-bbf82f1510d0.png)
 
 ```
-client_body_buffer_size 1m;
+client_body_buffer_size 512k;
 proxy_read_timeout 86400s;
 client_max_body_size 0;
 ```


### PR DESCRIPTION
based on (not identical): https://ssl-config.mozilla.org/#server=nginx&version=1.27.3&config=intermediate&openssl=3.4.0&hsts=false&ocsp=false&guideline=5.7