### PR TITLE
rp-docs: comments out http3_stream_buffer_size 512k in nginx template

### DIFF
--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -368,7 +368,7 @@ server {
 
     client_max_body_size 0;
     client_body_buffer_size 512k;
-    http3_stream_buffer_size 512k;
+    # http3_stream_buffer_size 512k; # uncomment to enable HTTP/3 / QUIC - supported on nginx v1.25.0+
     proxy_read_timeout 86400s;
 
     server_name <your-nc-domain>;


### PR DESCRIPTION
comments out http3_stream_buffer_size 512k as it requires v1.25.0+