### PR TITLE
Add local-ai community container with Nvidia GPU support via Cuda 12

### DIFF
--- a/community-containers/local-ai-cuda12/local-ai-cuda12.json
+++ b/community-containers/local-ai-cuda12/local-ai-cuda12.json
@@ -1,0 +1,49 @@
+{
+    "aio_services_v1": [
+        {
+            "container_name": "nextcloud-aio-local-ai-cuda12",
+            "display_name": "Local AI",
+            "documentation": "https://github.com/nextcloud/all-in-one/tree/main/community-containers/local-ai-cuda12",
+            "image": "luzfcb/aio-local-ai-cuda12",
+            "image_tag": "v2",
+            "internal_port": "8080",
+            "restart": "unless-stopped",
+            "environment": [
+                "TZ=%TIMEZONE%",
+                "MODELS_PATH=/models"
+            ],
+            "volumes": [
+                {
+                    "source": "nextcloud_aio_localai_models",
+                    "destination": "/models",
+                    "writeable": true
+                },
+                {
+                    "source": "nextcloud_aio_localai_images",
+                    "destination": "/tmp/generated/images/",
+                    "writeable": true
+                },
+                {
+                    "source": "%NEXTCLOUD_DATADIR%",
+                    "destination": "/nextcloud",
+                    "writeable": false
+                }
+            ],
+            "devices": [
+                "/dev/dri"
+            ],
+            "enable_nvidia_gpu": true,
+            "nextcloud_exec_commands": [
+                "mkdir '/mnt/ncdata/admin/files/nextcloud-aio-local-ai'",
+                "touch '/mnt/ncdata/admin/files/nextcloud-aio-local-ai/models.yaml'",
+                "echo 'Scanning nextcloud-aio-local-ai folder for admin user...'",
+                "php /var/www/html/occ files:scan --path='/admin/files/nextcloud-aio-local-ai'",
+                "php /var/www/html/occ app:install integration_openai",
+                "php /var/www/html/occ app:enable integration_openai",
+                "php /var/www/html/occ config:app:set integration_openai url --value http://nextcloud-aio-local-ai-cuda12:8080",
+                "php /var/www/html/occ app:install assistant",
+                "php /var/www/html/occ app:enable assistant"
+            ]
+        }
+    ]
+}

--- a/community-containers/local-ai-cuda12/readme.md
+++ b/community-containers/local-ai-cuda12/readme.md
@@ -1,0 +1,24 @@
+## Local AI Nvidia Cuda 12
+This container bundles Local AI with Nvidia GPU support via Cuda 12 and auto-configures it for you.
+
+
+### Notes
+- To use this, we need to have some additional environment variables configured in the Nextcloud AIO container:`ENABLE_NVIDIA_GPU=true`, `NEXTCLOUD_ENABLE_DRI_DEVICE=true` and include "local-ai-cuda12" in `AIO_COMMUNITY_CONTAINERS`
+ 
+- Make sure to have enough storage space available. This container alone needs ~48GB storage and probable aditional ~48GB when it update. That's ~96GB of free space. Every model that you add to `models.yaml` will of course use additional space which adds up quite fast.
+- After the container was started the first time, you should see a new `nextcloud-aio-local-ai` folder when you open the files app with the default `admin` user. In there you should see a `models.yaml` config file. You can now add models in there. Please refer [here](https://github.com/mudler/LocalAI/blob/master/gallery/index.yaml) where you can get further urls that you can put in there. Afterwards restart all containers from the AIO interface and the models should automatically get downloaded by the local-ai container and activated.
+- Example for content of `models.yaml` (if you add all of them, it takes around 10GB additional space):
+```yaml
+# Stable Diffusion in NCNN with c++, supported txt2img and img2img 
+- url: github:mudler/LocalAI/gallery/stablediffusion.yaml
+  name: Stable_diffusion
+```
+-  To make it work, you first need to browse `https://your-nc-domain.com/settings/admin/ai` and enable or disable specific features for your models in the openAI settings. Afterwards using the Nextcloud Assistant should work.
+- See [this guide](https://github.com/nextcloud/all-in-one/discussions/5430) for how to improve AI task pickup speed
+- See https://github.com/nextcloud/all-in-one/tree/main/community-containers#community-containers how to add it to the AIO stack
+
+### Repository
+https://github.com/luzfcb/aio-local-ai
+
+### Maintainer
+https://github.com/luzfcb


### PR DESCRIPTION
This is a fork of https://github.com/szaimen/aio-local-ai .
It basically uses `quay.io/go-skynet/local-ai:v2.24.2-aio-gpu-nvidia-cuda-12` instead of `quay.io/go-skynet/local-ai:v2.24.2-aio-cpu` as the base docker image, changes the start script a bit to show metadata about the GPUs/Nvidia GPUs and requires ~48GB to ~96GB of free disk space.