### PR TITLE
local-ai-cc: disable nvidia-gpu as it disallows the container to start

### DIFF
--- a/community-containers/local-ai/local-ai.json
+++ b/community-containers/local-ai/local-ai.json
@@ -29,10 +29,7 @@
                     "writeable": false
                 }
             ],
-            "devices": [
-                "/dev/dri"
-            ],
-            "enable_nvidia_gpu": true,
+            "enable_nvidia_gpu": false,
             "nextcloud_exec_commands": [
                 "mkdir '/mnt/ncdata/admin/files/nextcloud-aio-local-ai'",
                 "touch '/mnt/ncdata/admin/files/nextcloud-aio-local-ai/models.yaml'",


### PR DESCRIPTION
Follow-up to https://github.com/nextcloud/all-in-one/pull/5132