### PR TITLE
apache-healthcheck: remove the domain test

### DIFF
--- a/Containers/apache/healthcheck.sh
+++ b/Containers/apache/healthcheck.sh
@@ -3,7 +3,3 @@
 nc -z "$NEXTCLOUD_HOST" 9000 || exit 0
 nc -z 127.0.0.1 8000 || exit 1
 nc -z 127.0.0.1 "$APACHE_PORT" || exit 1
-if ! nc -z "$NC_DOMAIN" 443; then
-    echo "Could not reach $NC_DOMAIN on port 443."
-    exit 1
-fi


### PR DESCRIPTION
As this is not compatible with k8s.

Fix https://github.com/nextcloud/all-in-one/issues/5810