### PR TITLE
Support custom port for onlyoffice

### DIFF
--- a/Containers/apache/Caddyfile
+++ b/Containers/apache/Caddyfile
@@ -40,7 +40,7 @@ https://{$ADDITIONAL_TRUSTED_DOMAIN}:443,
     route /onlyoffice/* {
         uri strip_prefix /onlyoffice
         reverse_proxy {$ONLYOFFICE_HOST}:80 {
-            header_up X-Forwarded-Host {http.request.host}/onlyoffice
+            header_up X-Forwarded-Host {http.request.hostport}/onlyoffice
             header_up X-Forwarded-Proto https
         }
     }


### PR DESCRIPTION
In some cases, like usage of Nextcloud at home with a single IPv4 only, it is required to deploy the Nextcloud UI on a different port than 443. This can be achieved by configuring a domain value like "example.com:12345" in the mastercontainer's configuration.json file and using a custom reverse proxy configuration.

However onlyoffice will not work in this case. It relies on the X-Forwarded-Host header set in the Caddy config and will use the domain "https://example.com" without the custom port when constructing it's Javascript requests.

Caddy supports the variable {http.request.hostport}. By using this in the Caddyfile we can add support for custom ports.