### PR TITLE
fix: `pihole/pihole@latest` Web Admin interface

### DIFF
--- a/community-containers/pi-hole/pi-hole.json
+++ b/community-containers/pi-hole/pi-hole.json
@@ -28,9 +28,9 @@
             ],
             "environment": [
                 "TZ=%TIMEZONE%",
-                "WEBPASSWORD=%PIHOLE_WEBPASSWORD%",
-                "DNSMASQ_LISTENING=all",
-                "WEB_PORT=8573"
+                "FTLCONF_webserver_api_password=%PIHOLE_WEBPASSWORD%",
+                "FTLCONF_dns_listeningMode=all",
+                "FTLCONF_webserver_port=8573"
             ],
             "volumes": [
                 {


### PR DESCRIPTION
See: https://github.com/nextcloud/all-in-one/discussions/6064

`pihole/pihole@latest` has been updated to `v6`,
breaking the Web Admin interface at (http://192.168.x.x:8573/admin) (Pi-hole itself continues working fine, it seems)

- **Cause:** [V6 replaced `lighttpd` with an *embedded webserver* and changed most `pi-hole.json` *environment variables*](https://pi-hole.net/blog/2025/02/18/introducing-pi-hole-v6).
- **Fix:** This PR updates the environment variables to match the new v6 configuration.

Stopping and starting the container will apply the changes and should fix the Web Admin interface.

- **More:** https://docs.pi-hole.net/docker/upgrading/v5-v6/