### PR TITLE
Hide password by default

### DIFF
--- a/php/templates/components/container-state.twig
+++ b/php/templates/components/container-state.twig
@@ -16,7 +16,7 @@
   </span>
   {% if c.GetUiSecret() != '' %}
     <details>
-      <summary>Show password</summary>
+      <summary>Show password for {{ c.GetDisplayName() }}</summary>
       <p>{{ c.GetUiSecret() }}</p>
     </details>
   {% endif %}

--- a/php/templates/components/container-state.twig
+++ b/php/templates/components/container-state.twig
@@ -1,15 +1,19 @@
 {# @var c \App\Containers\Container #}
 <li>
-  {% if c.GetStartingState().value == 'starting' %}
-    <span class="status running"></span>
-  {% elseif c.GetRunningState().value == 'running' %}
-    <span class="status success"></span>
-  {% else %}
-    <span class="status error"></span>
-  {% endif %}
   <span>
-    {{ c.GetDisplayName() }}
-    (<a href="/api/docker/logs?id={{ c.GetIdentifier() }}" target="_blank">Stopped</a>)
+    {% if c.GetRunningState().value == 'running' %}
+      <span class="status success"></span>
+      {{ c.GetDisplayName() }}
+      (<a href="/api/docker/logs?id={{ c.GetIdentifier() }}" target="_blank">Running</a>)
+    {% elseif c.GetStartingState().value == 'starting' %}
+      <span class="status running"></span>
+      {{ c.GetDisplayName() }}
+      (<a href="/api/docker/logs?id={{ c.GetIdentifier() }}" target="_blank">Starting</a>)
+    {% else %}
+      <span class="status error"></span>
+      {{ c.GetDisplayName() }}
+      (<a href="/api/docker/logs?id={{ c.GetIdentifier() }}" target="_blank">Stopped</a>)
+    {% endif %}
     {% if c.GetDocumentation() != '' %}
       (<a target="_blank" href="{{ c.GetDocumentation() }}">docs</a>)
     {% endif %}
@@ -17,7 +21,7 @@
   {% if c.GetUiSecret() != '' %}
     <details>
       <summary>Show password for {{ c.GetDisplayName() }}</summary>
-      <p>{{ c.GetUiSecret() }}</p>
+      <input type="text" value="{{ c.GetUiSecret() }}" readonly>
     </details>
   {% endif %}
 </li>

--- a/php/templates/components/container-state.twig
+++ b/php/templates/components/container-state.twig
@@ -1,0 +1,23 @@
+{# @var c \App\Containers\Container #}
+<li>
+  {% if c.GetStartingState().value == 'starting' %}
+    <span class="status running"></span>
+  {% elseif c.GetRunningState().value == 'running' %}
+    <span class="status success"></span>
+  {% else %}
+    <span class="status error"></span>
+  {% endif %}
+  <span>
+    {{ c.GetDisplayName() }}
+    (<a href="/api/docker/logs?id={{ c.GetIdentifier() }}" target="_blank">Stopped</a>)
+    {% if c.GetDocumentation() != '' %}
+      (<a target="_blank" href="{{ c.GetDocumentation() }}">docs</a>)
+    {% endif %}
+  </span>
+  {% if c.GetUiSecret() != '' %}
+    <details>
+      <summary>Show password</summary>
+      <p>{{ c.GetUiSecret() }}</p>
+    </details>
+  {% endif %}
+</li>

--- a/php/templates/containers.twig
+++ b/php/templates/containers.twig
@@ -275,39 +275,7 @@
                             {# @var containers \AIO\Container\Container[] #}
                             {% for container in containers %}
                                 {% if container.GetDisplayName() != '' %}
-                                    <li>
-                                        {% if container.GetStartingState().value == 'starting' %}
-                                            <span class="status running"></span>
-                                            <span>{{ container.GetDisplayName() }} (<a href="/api/docker/logs?id={{ container.GetIdentifier() }}" target="_blank">Starting</a>)
-                                            {% if container.GetDocumentation() != '' %}
-                                                (<a target="_blank" href="{{ container.GetDocumentation() }}">docs</a>)
-                                            {% endif %}
-                                            {% if container.GetUiSecret() != '' %}
-                                                (password: {{ container.GetUiSecret() }})
-                                            {% endif %}
-                                            </span>
-                                        {% elseif container.GetRunningState().value == 'running' %}
-                                            <span class="status success"></span>
-                                            <span>{{ container.GetDisplayName() }} (<a href="/api/docker/logs?id={{ container.GetIdentifier() }}" target="_blank">Running</a>)
-                                            {% if container.GetDocumentation() != '' %}
-                                                (<a target="_blank" href="{{ container.GetDocumentation() }}">docs</a>)
-                                            {% endif %}
-                                            {% if container.GetUiSecret() != '' %}
-                                                (password: {{ container.GetUiSecret() }})
-                                            {% endif %}
-                                            </span>
-                                        {% else %}
-                                            <span class="status error"></span>
-                                            <span>{{ container.GetDisplayName() }} (<a href="/api/docker/logs?id={{ container.GetIdentifier() }}" target="_blank">Stopped</a>)
-                                            {% if container.GetDocumentation() != '' %}
-                                                (<a target="_blank" href="{{ container.GetDocumentation() }}">docs</a>)
-                                            {% endif %}
-                                            {% if container.GetUiSecret() != '' %}
-                                                (password: {{ container.GetUiSecret() }})
-                                            {% endif %}
-                                            </span>
-                                        {% endif %}
-                                    </li>
+                                    {% include 'components/container-state.twig'  with {'c': container} only %}
                                 {% endif %}
                             {% endfor %}
                         </ul>


### PR DESCRIPTION
Hi,

I found some time to do this. Now, the password is not displayed by default.

I didn't work on the design, but I moved the code to a components folder and used include with only from twig.
See: https://twig.symfony.com/doc/3.x/tags/include.html

![image](https://github.com/user-attachments/assets/de2c6298-55f6-47be-9d79-ab064d9f3077)
![image](https://github.com/user-attachments/assets/58ebe8ab-e6c3-4981-bd0e-b2f4263e87c9)

Fix part of https://github.com/nextcloud/all-in-one/issues/5954