### PR TITLE
Update docjyJ's community container images

### DIFF
--- a/community-containers/nocodb/nocodb.json
+++ b/community-containers/nocodb/nocodb.json
@@ -4,8 +4,8 @@
             "container_name": "nextcloud-aio-nocodb",
             "display_name": "NocoDB",
             "documentation": "https://github.com/nextcloud/all-in-one/tree/main/community-containers/nocodb",
-            "image": "docjyj/aio-nocodb",
-            "image_tag": "%AIO_CHANNEL%",
+            "image": "nocodb/nocodb",
+            "image_tag": "latest",
             "internal_port": "10028",
             "restart": "unless-stopped",
             "ports": [

--- a/community-containers/nocodb/readme.md
+++ b/community-containers/nocodb/readme.md
@@ -22,7 +22,7 @@ This is an alternative of **Airtable**.
 - See https://github.com/nextcloud/all-in-one/tree/main/community-containers#community-containers how to add it to the AIO stack
 
 ### Repository
-https://github.com/docjyJ/aio-nocodb
+https://github.com/nocodb/nocodb
 
 ### Maintainer
 https://github.com/docjyJ

--- a/community-containers/stalwart/stalwart.json
+++ b/community-containers/stalwart/stalwart.json
@@ -4,7 +4,7 @@
             "container_name": "nextcloud-aio-stalwart",
             "display_name": "Stalwart",
             "documentation": "https://github.com/nextcloud/all-in-one/tree/main/community-containers/stalwart",
-            "image": "docjyj/aio-stalwart",
+            "image": "ghcr.io/docjyj/aio-stalwart",
             "image_tag": "%AIO_CHANNEL%",
             "internal_port": "10003",
             "restart": "unless-stopped",


### PR DESCRIPTION
- Support of ghcr.io of Stalwart CC (Need #6134)
- Use the official image for NocoDB (NocoDB doesn't break between versions, it seems stable)