### PR TITLE
Change stalwart tag

### DIFF
--- a/community-containers/stalwart/stalwart.json
+++ b/community-containers/stalwart/stalwart.json
@@ -5,7 +5,7 @@
             "display_name": "Stalwart",
             "documentation": "https://github.com/nextcloud/all-in-one/tree/main/community-containers/stalwart",
             "image": "ghcr.io/docjyj/aio-stalwart",
-            "image_tag": "%AIO_CHANNEL%",
+            "image_tag": "v3",
             "internal_port": "10003",
             "restart": "unless-stopped",
             "ports": [


### PR DESCRIPTION
Hi,
I think it's better to use the `v3` tag. If I ever need to upgrade to `v4`, I could ask to create a develop container with a `v4` tag to run all the tests.