### PR TITLE
clamav: use correct clamd.conf in freshclam

### DIFF
--- a/Containers/clamav/supervisord.conf
+++ b/Containers/clamav/supervisord.conf
@@ -13,7 +13,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
-command=freshclam --foreground --stdout --daemon
+command=freshclam --foreground --stdout --daemon --daemon-notify=/tmp/clamd.conf
 
 [program:clamd]
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
From freshclam --help:
--daemon-notify[=/path/clamd.conf]   Send RELOAD command to clamd
