### PR TITLE
Update reverse-proxy.md for Collabora Compatibility

### DIFF
--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -420,6 +420,63 @@ server {
 
     server_name <your-nc-domain>;
 
+    # Static files for Collabora Online
+    location ^~ /browser {
+        proxy_pass http://127.0.0.1:11000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        # WOPI discovery URL
+        location ^~ /hosting/discovery {
+        proxy_pass http://127.0.0.1:11000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # Main websocket channel (COOLWSD)
+    location ^~ /cool {
+        proxy_pass http://127.0.0.1:11000;
+        proxy_set_header Host $host;
+        proxy_read_timeout 3600s;
+
+        # WebSocket settings
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade"; # Use literal "upgrade"
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # Admin Console websocket channel
+    location ^~ /cool/adminws {
+        proxy_pass http://127.0.0.1:11000;
+        proxy_set_header Host $host;
+        proxy_read_timeout 3600s;
+
+        # WebSocket settings
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade"; # Use literal "upgrade"
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # Download endpoint (if needed, sometimes handled by /cool)
+    location ^~ /download {
+        proxy_pass http://127.0.0.1:11000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
     location / {
         proxy_pass http://127.0.0.1:11000$request_uri; # Adjust to match APACHE_PORT and APACHE_IP_BINDING. See https://github.com/nextcloud/all-in-one/blob/main/reverse-proxy.md#adapting-the-sample-web-server-configurations-below
 


### PR DESCRIPTION
Added 'location ^~ /*' lines for collabora compatibility as the current config does now allow for collabora use and just results in a time out.

There may be some oddities so I encourage discussing what's been added to drill down to a proper solution for everyone to use. I mainly got to this point after arguing with Google Gemini 2.5 Pro for a fair bit of time but ultimately got collabora working.