### PR TITLE
feat(docker-socket-proxy): allow inspect image rule

### DIFF
--- a/Containers/docker-socket-proxy/haproxy.cfg
+++ b/Containers/docker-socket-proxy/haproxy.cfg
@@ -14,6 +14,8 @@ frontend http
     http-request deny unless { src 127.0.0.1 } || { src ::1 } || { src NC_IPV4_PLACEHOLDER } || { src NC_IPV6_PLACEHOLDER }
     # docker system _ping
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/_ping$ } METH_GET
+    # docker inspect image: GET images/%s/json
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/images/.*/json } METH_GET
     # container inspect: GET containers/%s/json
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/nc_app_[a-zA-Z0-9_.-]+/json } METH_GET
     # container inspect: GET containers/%s/logs


### PR DESCRIPTION
Allow `/images/{name}/json`.

Ref: https://github.com/nextcloud/docker-socket-proxy/pull/47, required for: https://github.com/nextcloud/app_api/pull/554