### PR TITLE
Docker-socket-proxy: Update haproxy.cfg to fix timeouts

### DIFF
--- a/Containers/docker-socket-proxy/haproxy.cfg
+++ b/Containers/docker-socket-proxy/haproxy.cfg
@@ -4,9 +4,9 @@ global
     maxconn 10
 
 defaults
-    timeout connect 10s
-    timeout client 10s
-    timeout server 10s
+    timeout connect 60s
+    timeout client 60s
+    timeout server 60s
 
 frontend http
     mode http

--- a/Containers/docker-socket-proxy/haproxy.cfg
+++ b/Containers/docker-socket-proxy/haproxy.cfg
@@ -4,9 +4,9 @@ global
     maxconn 10
 
 defaults
-    timeout connect 60s
-    timeout client 60s
-    timeout server 60s
+    timeout connect 30s
+    timeout client 30s
+    timeout server 1800s
 
 frontend http
     mode http


### PR DESCRIPTION
Due to some testing its possible to install the agent via occ and the frontend by setting this on 60s. Lower values didn't work in my testing.