### PR TITLE
nextcloud: update imagick to 3.8.0 and revert imagick workaround

### DIFF
--- a/.github/workflows/nextcloud-update.yml
+++ b/.github/workflows/nextcloud-update.yml
@@ -60,12 +60,6 @@ jobs:
         )"
         sed -i "s|\(pecl install[^;]*imagick-\)[0-9.]*|\1$imagick_version|" ./Containers/nextcloud/Dockerfile
 
-        # Imagick git-commit-hash from HEAD
-        imagick_commit_hash="$(
-          git ls-remote https://github.com/imagick/imagick.git HEAD | awk '{print $1}'
-        )"
-        sed -i "s/\(ARG IMAGICK_COMMIT_HASH=\)[a-fA-F0-9]*$/\1$imagick_commit_hash/" ./Containers/nextcloud/Dockerfile
-
         # Igbinary
         igbinary_version="$(
           git ls-remote --tags https://github.com/igbinary/igbinary.git \

--- a/Containers/nextcloud/Dockerfile
+++ b/Containers/nextcloud/Dockerfile
@@ -13,9 +13,6 @@ ENV AIO_TOKEN=123456
 ENV AIO_URL=localhost
 # AIO settings end # Do not remove or change this line!
 
-# Define the commit hash for imagick as a variable
-ARG IMAGICK_COMMIT_HASH=28f27044e435a2b203e32675e942eb8de620ee58
-
 COPY --chmod=775 *.sh /
 COPY --chmod=774 upgrade.exclude /upgrade.exclude
 COPY config/*.php /
@@ -85,20 +82,7 @@ RUN set -ex; \
     pecl install APCu-5.1.24; \
     pecl install -D 'enable-memcached-igbinary="yes"' memcached-3.3.0; \
     pecl install -oD 'enable-redis-igbinary="yes" enable-redis-zstd="yes" enable-redis-lz4="yes"' redis-6.2.0; \
-#    pecl install -o imagick-3.7.0; \
-# Begin workaround ->
-# The master version on the imagick repository is compatible with PHP 8.3. However, the PECL version is not updated yet.
-# As soon as it will get updated, we can switch back to the PECL version, instead of having this workaround.
-    apk add --no-cache --virtual .git-build-deps git \
-    && git clone https://github.com/imagick/imagick.git --depth 1 /tmp/imagick \
-    && cd /tmp/imagick \
-    && git fetch --depth 1 origin ${IMAGICK_COMMIT_HASH} \
-    && git checkout ${IMAGICK_COMMIT_HASH} \
-    && sed -i "s/@PACKAGE_VERSION@/git-${IMAGICK_COMMIT_HASH:0:7}/" php_imagick.h \
-    && phpize && ./configure && make && make install; \
-    apk del .git-build-deps; \
-    cd && rm -r /tmp/imagick; \
-# <- End workaround
+   pecl install -o imagick-3.8.0; \
     \
     docker-php-ext-enable \
         igbinary \


### PR DESCRIPTION
Close https://github.com/nextcloud/all-in-one/issues/5582