### PR TITLE
containers.json: always add chown cap to collabora

### DIFF
--- a/php/containers.json
+++ b/php/containers.json
@@ -393,7 +393,8 @@
       ],
       "cap_add": [
         "MKNOD",
-        "SYS_ADMIN"
+        "SYS_ADMIN",
+        "CHOWN"
       ],
       "cap_drop": [
         "NET_RAW"


### PR DESCRIPTION
as suggested in https://help.nextcloud.com/t/collabora-performance-issues-with-fresh-nextcloud-aio-install/219429/2