### PR TITLE
Revert "nextcloud: add pandoc to container"

### DIFF
--- a/Containers/nextcloud/Dockerfile
+++ b/Containers/nextcloud/Dockerfile
@@ -227,7 +227,6 @@ RUN set -ex; \
         grep \
         nodejs \
         libreoffice \
-        pandoc-cli \
         bind-tools \
         imagemagick \
         imagemagick-svg \


### PR DESCRIPTION
Reverts nextcloud/all-in-one#6441

Reason: looks like the integration app is abandoned: https://apps.nextcloud.com/apps/pandoc