### PR TITLE
DockerController: avoid php warning when id not in query string in GetLogs Route

### DIFF
--- a/php/src/Controller/DockerController.php
+++ b/php/src/Controller/DockerController.php
@@ -62,7 +62,11 @@ readonly class DockerController {
 
     public function GetLogs(Request $request, Response $response, array $args) : Response
     {
-        $id = $request->getQueryParams()['id'];
+        $requestParams = $request->getQueryParams();
+        $id = '';
+        if (is_string($requestParams['id'])) {
+            $id = $requestParams['id'];
+        }
         if (str_starts_with($id, 'nextcloud-aio-')) {
             $logs = $this->dockerActionManager->GetLogs($id);
         } else {


### PR DESCRIPTION
Fix https://github.com/nextcloud/all-in-one/issues/6413
