### PR TITLE
Make daily-backup.sh more robust by checking for uninitialized state

### DIFF
--- a/Containers/mastercontainer/daily-backup.sh
+++ b/Containers/mastercontainer/daily-backup.sh
@@ -3,9 +3,9 @@
 echo "Daily backup script has started"
 
 # Check if initial configuration has been done, otherwise this script should do nothing.
-configFile=/mnt/docker-aio-config/data/configuration.json
-if [ ! -f "$configFile" ] || ! grep -q -E '"wasStartButtonClicked"\s*:\s*1\s*,' "$configFile"; then
-    echo "Initial configuration not done yet. Exiting..."
+CONFIG_FILE=/mnt/docker-aio-config/data/configuration.json
+if ! [ -f "$CONFIG_FILE" ] || ! grep -q "wasStartButtonClicked.*1" "$CONFIG_FILE"; then
+    echo "Initial configuration via AIO interface not done yet. Exiting..."
     exit 0
 fi
 

--- a/Containers/mastercontainer/daily-backup.sh
+++ b/Containers/mastercontainer/daily-backup.sh
@@ -2,6 +2,13 @@
 
 echo "Daily backup script has started"
 
+# Check if initial configuration has been done, otherwise this script should do nothing.
+configFile=/mnt/docker-aio-config/data/configuration.json
+if [ ! -f "$configFile" ] || ! grep -q -E '"wasStartButtonClicked"\s*:\s*1\s*,' "$configFile"; then
+    echo "Initial configuration not done yet. Exiting..."
+    exit 0
+fi
+
 # Daily backup and backup check cannot be run at the same time
 if [ "$DAILY_BACKUP" = 1 ] && [ "$CHECK_BACKUP" = 1 ]; then
     echo "Daily backup and backup check cannot be run at the same time. Exiting..."


### PR DESCRIPTION
Adding a guard check in daily-backup.sh to detect uninitialized state to make it more robust. 
This is continuation with the discussion on https://github.com/nextcloud/all-in-one/discussions/5994#discussioncomment-12335738

**Background summary**
Podman containers have native integration with systemd with the ability to start/stop/restart services using `systemctl start XXXX.service` at reboots, other service interactions etc. Because AIO container itself is just the wrapper, there's a need for programmatic mechanism to do "Start Containers" or "Stop Containers"  similar to the buttons exposed in the WebUI of mastercontainer; and then the systemd service can use them for graceful start/stop of whole of AIO+Nextcloud. The `daily-backup.sh` script is quite useful for this purpose:
- Start command: `podman exec -it --env START_CONTAINERS=1 nextcloud-aio-mastercontainer /daily-backup.sh`
- Stop command: `podman exec -it --env STOP_CONTAINERS=1 nextcloud-aio-mastercontainer /daily-backup.sh`

This has been working working quite well - been using it for ~6 months with once-a-week reboots.
But as pointed out in earlier discussion, above will reach undefined behavior if someone reboots the machine / restarts the service on a fresh installation with configuration not yet done.
This PR improves that by handling this corner case and exiting early.

PS: Using `grep` to do the check is an implementation choice. Another alternative would be to add `jq` package to mastercontainer image and use that to parse configuration.json more reliably. 