### PR TITLE
Fix signal handling for mastercontainer

### DIFF
--- a/Containers/mastercontainer/start.sh
+++ b/Containers/mastercontainer/start.sh
@@ -366,4 +366,4 @@ caddy fmt --overwrite /Caddyfile
 chmod 777 /root
 
 # Start supervisord
-/usr/bin/supervisord -c /supervisord.conf
+exec /usr/bin/supervisord -c /supervisord.conf


### PR DESCRIPTION
When stopping the mastercontainer, docker / podman send SIGQUIT / SIGTERM to the container. These are not handled today and that's why docker/podman just force kill the containers. The supervisord already knows how to handle these signals, but the signals are intercepted by the bash process and never reach supervisord.
This PR fixes that by using bash process replacement, so supervisord becomes the primary process once it runs and can receive signals. With this container stopping becomes graceful and not a force kill. 