### PR TITLE
Revert "build(deps): bump onlyoffice/documentserver from 8.3.3.1 to 9.0.2.1 in /Containers/onlyoffice"

### DIFF
--- a/Containers/onlyoffice/Dockerfile
+++ b/Containers/onlyoffice/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:latest
 # From https://github.com/ONLYOFFICE/Docker-DocumentServer/blob/master/Dockerfile
-FROM onlyoffice/documentserver:9.0.2.1
+FROM onlyoffice/documentserver:8.3.3.1
 
 # USER root is probably used
 


### PR DESCRIPTION
Reverts nextcloud/all-in-one#6587