### PR TITLE
db-import: improve the import process by using the `smart` mode and a higher timeout

### DIFF
--- a/Containers/postgresql/start.sh
+++ b/Containers/postgresql/start.sh
@@ -128,7 +128,9 @@ EOSQL
     fi
 
     # Shut down the database to be able to start it again
-    pg_ctl stop -m fast
+    # The smart mode disallows new connections, then waits for all existing clients to disconnect and any online backup to finish
+    # Wait for 1800s to make sure that a checkpoint is completed successfully
+    pg_ctl stop -m smart -t 1800
 
     # Change database port back to default
     export PGPORT=5432


### PR DESCRIPTION
For https://help.nextcloud.com/t/database-import-and-backup-restore-failed/227952