### PR TITLE
aio-interface: add hint to UI about SSH pubkey for remote backups

### DIFF
--- a/php/templates/containers.twig
+++ b/php/templates/containers.twig
@@ -371,6 +371,7 @@
                                 <p>
                                 To store backups remotely instead, fill in the
                                 <a target="_blank" href="https://borgbackup.readthedocs.io/en/stable/usage/general.html#repository-urls">remote borg repo url and submit it</a>.
+                                You will be provided with an SSH public key for authorization at the remote afterwards.
                                 </p>
                                 <form method="POST" action="/api/configuration" class="xhr">
                                     <label>Local backup location</label> <input type="text" id="borg_backup_host_location" name="borg_backup_host_location" placeholder="/mnt/backup"/><br>


### PR DESCRIPTION
background is: I thought for 15 min about how Nextcloud/Borg does authenticate on the remote backup location. The first hint I found was this blog entry: https://nextcloud.com/blog/how-to-back-up-restore-nextcloud-remotely-using-borg/

Because that took too long to find, IMO a hint should be added so new users learn about:
- that SSH public keys are used
- that one is generated by Nextcloud/Borg for you