### PR TITLE
feat(borgbackup): add support for bind-mounted SSH keys

### DIFF
--- a/Containers/mastercontainer/start.sh
+++ b/Containers/mastercontainer/start.sh
@@ -331,6 +331,27 @@ chown www-data:www-data -R /mnt/docker-aio-config/session/
 chown www-data:www-data -R /mnt/docker-aio-config/caddy/
 chown root:root -R /mnt/docker-aio-config/certs/
 
+# Handle SSH key propagation for borgbackup
+BORG_KEY_PATH="/mnt/docker-aio-config/data/id_borg"
+BORG_KEY_PUB_PATH="/mnt/docker-aio-config/data/id_borg.pub"
+BORG_KEY_MOUNT_PATH="/mnt/docker-aio-config/data/id_borg_mount"
+BORG_KEY_PUB_MOUNT_PATH="/mnt/docker-aio-config/data/id_borg_mount.pub"
+
+# Check if borg keys don't exist and mounted keys do exist, then copy them
+if [ ! -f "$BORG_KEY_PATH" ] && [ -f "$BORG_KEY_MOUNT_PATH" ]; then
+    print_green "Copying mounted SSH private key for borgbackup..."
+    cp "$BORG_KEY_MOUNT_PATH" "$BORG_KEY_PATH"
+    chmod 600 "$BORG_KEY_PATH"
+    chown www-data:www-data "$BORG_KEY_PATH"
+fi
+
+if [ ! -f "$BORG_KEY_PUB_PATH" ] && [ -f "$BORG_KEY_PUB_MOUNT_PATH" ]; then
+    print_green "Copying mounted SSH public key for borgbackup..."
+    cp "$BORG_KEY_PUB_MOUNT_PATH" "$BORG_KEY_PUB_PATH"
+    chmod 644 "$BORG_KEY_PUB_PATH"
+    chown www-data:www-data "$BORG_KEY_PUB_PATH"
+fi
+
 # Don't allow access to the AIO interface from the Nextcloud container
 # Probably more cosmetic than anything but at least an attempt
 if ! grep -q '# nextcloud-aio-block' /etc/apache2/httpd.conf; then

--- a/readme.md
+++ b/readme.md
@@ -776,7 +776,14 @@ If you want to back up directly to a remote borg repository:
 1. Create your borg repository at the remote. Note down the repository URL for later.
 2. Open the AIO interface
 3. Under backup section, leave the local path blank and fill in the url to your borg repository that you noted down earlier.
-4. Click on `Create backup`, this will create an ssh key pair and fail because the remote doesn't trust this key yet. Copy the public key shown in AIO and add it to your authorized keys on the remote.
+4. Click on `Create backup`, this will create an ssh key pair and fail because the remote doesn't trust this key yet. Copy the public key shown in AIO and add it to your authorized keys on the remote. 
+
+   Alternatively, if you already have SSH keys for your remote repository, you can bind mount them to the mastercontainer:
+   - Private key: `-v /path/to/your/id_borg:/mnt/docker-aio-config/data/id_borg_mount:ro`
+   - Public key: `-v /path/to/your/id_borg.pub:/mnt/docker-aio-config/data/id_borg_mount.pub:ro`
+   
+   The keys will be automatically copied to the correct location on container start.
+
 5. Try again to create a backup, this time it should succeed.
 
 </details>


### PR DESCRIPTION
Enable users to provide existing SSH keys for remote borgbackup repositories by bind mounting them to the mastercontainer. Keys mounted at id_borg_mount and id_borg_mount.pub are automatically copied to the expected locations on startup, allowing reuse of existing SSH credentials.