### PR TITLE
Use a fixed port for internal WOPI requests and callbacks

### DIFF
--- a/Containers/apache/Caddyfile
+++ b/Containers/apache/Caddyfile
@@ -15,7 +15,7 @@
 }
 
 https://{$ADDITIONAL_TRUSTED_DOMAIN}:443,
-http://{$APACHE_HOST}:{$APACHE_PORT}, # For Collabora callback
+http://{$APACHE_HOST}:23973, # For Collabora callback and WOPI requests, see containers.json
 {$PROTOCOL}://{$NC_DOMAIN}:{$APACHE_PORT} {
     header -Server
     header -X-Powered-By

--- a/php/containers.json
+++ b/php/containers.json
@@ -379,7 +379,7 @@
       ],
       "internal_port": "9980",
       "environment": [
-        "aliasgroup1=https://%NC_DOMAIN%:443,http://nextcloud-aio-apache:%APACHE_PORT%",
+        "aliasgroup1=https://%NC_DOMAIN%:443,http://nextcloud-aio-apache:23973",
         "extra_params=--o:ssl.enable=false --o:ssl.termination=true --o:mount_jail_tree=false --o:logging.level=warning --o:logging.level_startup=warning --o:home_mode.enable=true %COLLABORA_SECCOMP_POLICY% --o:remote_font_config.url=https://%NC_DOMAIN%/apps/richdocuments/settings/fonts.json --o:net.post_allow.host[0]=.+",
         "dictionaries=%COLLABORA_DICTIONARIES%",
         "TZ=%TIMEZONE%",
@@ -389,7 +389,7 @@
       "restart": "unless-stopped",
       "nextcloud_exec_commands": [
         "echo 'Activating Collabora config...'",
-        "php /var/www/html/occ richdocuments:activate-config --wopi-url='http://nextcloud-aio-apache:%APACHE_PORT%' --callback-url='http://nextcloud-aio-apache:%APACHE_PORT%'"
+        "php /var/www/html/occ richdocuments:activate-config --wopi-url='http://nextcloud-aio-apache:23973' --callback-url='http://nextcloud-aio-apache:23973'"
       ],
       "profiles": [
         "collabora"


### PR DESCRIPTION
This fixes the issue where Caddy fails to start when APACHE_PORT was 443.

See also [#6676](https://github.com/nextcloud/all-in-one/pull/6676#issuecomment-3258047014)

@szaimen This is one quick fix. Note that it should be OK if APACHE_PORT is also 23973. It would just end up with a block like this:
```
http://nextcloud-aio-apache:23973,
http://:23973
```
which is fine.
If APACHE_PORT is 443 we get this:
```
http://nextcloud-aio-apache:23973,
https://nextcloud.example.com:443
```
which should also work.