### PR TITLE
feat: Add shared_secrets and shared_environment for community containers

### DIFF
--- a/community-containers/facerecognition/facerecognition.json
+++ b/community-containers/facerecognition/facerecognition.json
@@ -10,18 +10,21 @@
             "restart": "unless-stopped",
             "environment": [
                 "TZ=%TIMEZONE%",
-                "API_KEY=some-super-secret-api-key",
+                "API_KEY=%FACERECOGNITION_API_KEY%",
                 "FACE_MODEL=3"
             ],
             "aio_variables": [
                 "nextcloud_memory_limit=2048M"
+            ],
+            "shared_secrets": [
+                "FACERECOGNITION_API_KEY"
             ],
             "enable_nvidia_gpu": false,
             "nextcloud_exec_commands": [
                 "php /var/www/html/occ app:install facerecognition",
                 "php /var/www/html/occ app:enable facerecognition", 
                 "php /var/www/html/occ config:system:set facerecognition.external_model_url --value nextcloud-aio-facerecognition:5000",
-                "php /var/www/html/occ config:system:set facerecognition.external_model_api_key --value some-super-secret-api-key",
+                "php /var/www/html/occ config:system:set facerecognition.external_model_api_key --value %FACERECOGNITION_API_KEY%",
                 "php /var/www/html/occ face:setup -m 5",
                 "php /var/www/html/occ face:setup -M 1G",
                 "php /var/www/html/occ config:app:set facerecognition analysis_image_area --value 4320000",

--- a/php/containers-schema.json
+++ b/php/containers-schema.json
@@ -57,6 +57,14 @@
 							"minlength": 1
 						}
 					},
+					"shared_environment": {
+						"type": "array",
+						"items": {
+							"type": "string",
+							"pattern": "^.*=.*$",
+							"minlength": 1
+						}
+					},
 					"container_name": {
 						"type": "string",
 						"pattern": "^nextcloud-aio-[a-z0-9-]+$"
@@ -139,6 +147,13 @@
 						"type": "integer"
 					},
 					"secrets": {
+						"type": "array",
+						"items": {
+							"type": "string",
+							"pattern": "^[A-Z_]+$"
+						}
+					},
+					"shared_secrets": {
 						"type": "array",
 						"items": {
 							"type": "string",

--- a/php/src/Container/Container.php
+++ b/php/src/Container/Container.php
@@ -17,10 +17,14 @@ readonly class Container {
         private string                        $internalPorts,
         private ContainerVolumes              $volumes,
         private ContainerEnvironmentVariables $containerEnvironmentVariables,
+        /** @var array */
+        private array                         $sharedEnvironment,
         /** @var string[] */
         private array                         $dependsOn,
         /** @var string[] */
         private array                         $secrets,
+        /** @var string[] */
+        private array                         $sharedSecrets,
         private string                        $uiSecret,
         /** @var string[] */
         private array                         $devices,
@@ -82,8 +86,20 @@ readonly class Container {
         return $this->maxShutdownTime;
     }
 
+    public function GetEnvironmentVariables() : ContainerEnvironmentVariables {
+        return $this->containerEnvironmentVariables;
+    }
+
+    public function GetSharedEnvironment() : array {
+        return $this->sharedEnvironment;
+    }
+
     public function GetSecrets() : array {
         return $this->secrets;
+    }
+
+    public function GetSharedSecrets() : array {
+        return $this->sharedSecrets;
     }
 
     public function GetUiSecret() : string {
@@ -147,10 +163,6 @@ readonly class Container {
 
     public function GetNextcloudExecCommands() : array {
         return $this->nextcloudExecCommands;
-    }
-
-    public function GetEnvironmentVariables() : ContainerEnvironmentVariables {
-        return $this->containerEnvironmentVariables;
     }
 
     public function GetAioVariables() : AioVariables {

--- a/php/src/ContainerDefinitionFetcher.php
+++ b/php/src/ContainerDefinitionFetcher.php
@@ -239,9 +239,19 @@ readonly class ContainerDefinitionFetcher {
                 $internalPort = $entry['internal_port'];
             }
 
+            $sharedEnvironment = [];
+            if (isset($entry['shared_environment'])) {
+                $sharedEnvironment = $entry['shared_environment'];
+            }
+
             $secrets = [];
             if (isset($entry['secrets'])) {
                 $secrets = $entry['secrets'];
+            }
+
+            $sharedSecrets = [];
+            if (isset($entry['shared_secrets'])) {
+                $sharedSecrets = $entry['shared_secrets'];
             }
 
             $uiSecret = '';
@@ -319,8 +329,10 @@ readonly class ContainerDefinitionFetcher {
                 $internalPort,
                 $volumes,
                 $variables,
+                $sharedEnvironment,
                 $dependsOn,
                 $secrets,
+                $sharedSecrets,
                 $uiSecret,
                 $devices,
                 $enableNvidiaGpu,


### PR DESCRIPTION
## Overview

This PR introduces two new concepts for community containers to securely share secrets and environment variables with all AIO containers, including Nextcloud.

Related: https://github.com/nextcloud/all-in-one/discussions/3889

I also added some explanation to the readme to make it a bit easier for new contributes.

## New Features

### 🔐 `shared_secrets`
To allow sharing secret from community containers to all other containers it is now possible to add a shared_secret array to the container json file.
That shared_secret behaves the same as the secret except that it is shard to all other containers. 

### 🌐 `shared_environment` 
- Environment variables that are automatically injected into **ALL** AIO containers
- Uses same format as regular `environment` array
- Supports full placeholder replacement (`%SECRET_NAME%`, `%TIMEZONE%`, etc.)
- Perfect for sharing service URLs, API keys, and configuration flags

## Example Usage

```json
{
    "secrets": ["FACERECOGNITION_API_KEY"],
    "shared_secrets": ["FACERECOGNITION_API_KEY"], 
    "shared_environment": [
        "FACERECOGNITION_API_KEY=%FACERECOGNITION_API_KEY%",
        "FACERECOGNITION_URL=http://nextcloud-aio-facerecognition:5000"
    ],
    "nextcloud_exec_commands": [
        "php /var/www/html/occ config:system:set facerecognition.external_model_api_key --value %FACERECOGNITION_API_KEY%"
    ]
}