### PR TITLE
feat: Share declared secrets between all enabled containers

### DIFF
--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -221,10 +221,6 @@ readonly class DockerActionManager {
             $requestBody['HostConfig']['Binds'] = $volumes;
         }
 
-        foreach ($container->GetSecrets() as $secret) {
-            $this->configurationManager->GetAndGenerateSecret($secret);
-        }
-
         $aioVariables = $container->GetAioVariables()->GetVariables();
         foreach ($aioVariables as $variable) {
             $config = $this->configurationManager->GetConfig();


### PR DESCRIPTION
As discussed in #6831 this PR makes the secrets shared by default.

This allows for example that a community container can declare a new secret that will also be available in the nextcloud container context and can be used via string substitution in the nextcloud_exec area.

That also means that community containers sharing secrets from the core containers do not need to declare that but it doesn't hurt either and adds some clarity maybe.

Replaces #6831, #6835

I tested the fresh AIO creation but not an upgrade :)