### PR TITLE
Make secrets global and init on first use

### DIFF
--- a/php/src/Container/Container.php
+++ b/php/src/Container/Container.php
@@ -19,8 +19,6 @@ readonly class Container {
         private ContainerEnvironmentVariables $containerEnvironmentVariables,
         /** @var string[] */
         private array                         $dependsOn,
-        /** @var string[] */
-        private array                         $secrets,
         private string                        $uiSecret,
         /** @var string[] */
         private array                         $devices,
@@ -80,10 +78,6 @@ readonly class Container {
 
     public function GetMaxShutdownTime() : int {
         return $this->maxShutdownTime;
-    }
-
-    public function GetSecrets() : array {
-        return $this->secrets;
     }
 
     public function GetUiSecret() : string {

--- a/php/src/ContainerDefinitionFetcher.php
+++ b/php/src/ContainerDefinitionFetcher.php
@@ -239,9 +239,12 @@ readonly class ContainerDefinitionFetcher {
                 $internalPort = $entry['internal_port'];
             }
 
-            $secrets = [];
             if (isset($entry['secrets'])) {
-                $secrets = $entry['secrets'];
+                // All secrets are registered with the configuration when they 
+                // are discovered so they can be later generated at time-of-use.
+                foreach ($entry['secrets'] as $secret) {
+                    $this->configurationManager->RegisterSecret($secret);
+                }
             }
 
             $uiSecret = '';
@@ -320,7 +323,6 @@ readonly class ContainerDefinitionFetcher {
                 $volumes,
                 $variables,
                 $dependsOn,
-                $secrets,
                 $uiSecret,
                 $devices,
                 $enableNvidiaGpu,

--- a/php/src/Data/ConfigurationManager.php
+++ b/php/src/Data/ConfigurationManager.php
@@ -7,6 +7,8 @@ use AIO\Controller\DockerController;
 
 class ConfigurationManager
 {
+    private array $secrets = [];
+
     public function GetConfig() : array
     {
         if(file_exists(DataConst::GetConfigFile()))
@@ -50,13 +52,15 @@ class ConfigurationManager
         return $config['secrets'][$secretId];
     }
 
-    public function GetSecret(string $secretId) : string {
-        $config = $this->GetConfig();
-        if(!isset($config['secrets'][$secretId])) {
-            $config['secrets'][$secretId] = "";
+    public function GetRegisteredSecret(string $secretId) : string {
+        if ($this->secrets[$secretId]) {
+            return $this->GetAndGenerateSecret($secretId);
         }
+        throw new \Exception("The secret " . $secretId . " was not registered. Please check if it is defined in secrets of containers.json.");
+    }
 
-        return $config['secrets'][$secretId];
+    public function RegisterSecret(string $secretId) : void {
+        $this->secrets[$secretId] = true;
     }
 
     private function DoubleSafeBackupSecret(string $borgBackupPassword) : void {

--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -221,10 +221,6 @@ readonly class DockerActionManager {
             $requestBody['HostConfig']['Binds'] = $volumes;
         }
 
-        foreach ($container->GetSecrets() as $secret) {
-            $this->configurationManager->GetAndGenerateSecret($secret);
-        }
-
         $aioVariables = $container->GetAioVariables()->GetVariables();
         foreach ($aioVariables as $variable) {
             $config = $this->configurationManager->GetConfig();
@@ -566,16 +562,8 @@ readonly class DockerActionManager {
             // Allow to get local ip-address of caddy container and add it to trusted proxies automatically
             'CADDY_IP_ADDRESS' => in_array('caddy', $this->configurationManager->GetEnabledCommunityContainers(), true) ? gethostbyname('nextcloud-aio-caddy') : '',
             'WHITEBOARD_ENABLED' => $this->configurationManager->isWhiteboardEnabled() ? 'yes' : '',
-            default => $this->getSecretOrThrow($placeholder),
+            default => $this->configurationManager->GetRegisteredSecret($placeholder),
         };
-    }
-
-    private function getSecretOrThrow(string $secretName): string {
-        $secret = $this->configurationManager->GetSecret($secretName);
-        if ($secret === "") {
-            throw new \Exception("The secret " . $secretName . " is empty. Cannot substitute its value. Please check if it is defined in secrets of containers.json.");
-        }
-        return $secret;
     }
 
     private function isContainerUpdateAvailable(string $id): string {


### PR DESCRIPTION
This allows all containers to use any secret declared anywhere in their placeholders but they will not be generated and written to the configuration until they are used.