### PR TITLE
aio-interface setup page: fall back to system fonts if monospace does not exist

### DIFF
--- a/php/public/style.css
+++ b/php/public/style.css
@@ -220,7 +220,7 @@ svg:not(:has(use)) .fallback-text {
 }
 
 .login > .monospace {
-    font-family: monospace;
+    font-family: monospace, monospace, system-ui, -apple-system, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, Ubuntu, 'Helvetica Neue', 'Noto Sans', 'Liberation Sans', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
     font-size: 17px;
 }
 


### PR DESCRIPTION
Fix https://github.com/nextcloud/all-in-one/issues/6840