### PR TITLE
WIP: add clamav milter to nextcloud-aio-clamav container

### DIFF
--- a/Containers/clamav/Dockerfile
+++ b/Containers/clamav/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.22.1
 
 RUN set -ex; \
     apk upgrade --no-cache -a; \
-    apk add --no-cache tzdata clamav supervisor bash; \
+    apk add --no-cache tzdata clamav clamav-milter supervisor bash; \
     mkdir -p /var/lib/clamav /run/clamav /var/log/supervisord /var/run/supervisord; \
     chmod 777 -R /run/clamav /var/log/clamav /var/log/supervisord /var/run/supervisord; \
     chown -R 100:100 /var/lib/clamav; \
@@ -12,7 +12,11 @@ RUN set -ex; \
     sed -i "s|#\?PCREMaxFileSize.*|PCREMaxFileSize aio-placeholder|g" /etc/clamav/clamd.conf; \
     sed -i "s|#\?StreamMaxLength.*|StreamMaxLength aio-placeholder|g" /etc/clamav/clamd.conf; \
     sed -i "s|#\?TCPSocket|TCPSocket|g" /etc/clamav/clamd.conf; \
-    sed -i "s|^LocalSocket .*|LocalSocket /tmp/clamd.sock|g" /etc/clamav/clamd.conf
+    sed -i "s|^LocalSocket .*|LocalSocket /tmp/clamd.sock|g" /etc/clamav/clamd.conf; \
+    sed -i "s|Example| |g" /etc/clamav/clamav-milter.conf; \
+    sed -i "s|#\?MilterSocket inet:7357|MilterSocket inet:7357|g" /etc/clamav/clamav-milter.conf; \
+    sed -i "s|#\?ClamdSocket unix:/run/clamav/clamd.sock|ClamdSocket unix:/tmp/clamd.sock|g" /etc/clamav/clamav-milter.conf; \
+    sed -i "s|#\?AddHeader Replace|AddHeader Add|g" /etc/clamav/clamav-milter.conf
 
 COPY --chmod=775 start.sh /start.sh
 COPY --chmod=775 healthcheck.sh /healthcheck.sh

--- a/Containers/clamav/start.sh
+++ b/Containers/clamav/start.sh
@@ -2,6 +2,10 @@
 
 sed "s|aio-placeholder|$MAX_SIZE|" /etc/clamav/clamd.conf > /tmp/clamd.conf
 
+if [ "${STALWART}" ]; then
+  cp /etc/clamav/clamav-milter.conf /tmp/clamv-milter-conf
+fi
+
 # Print out clamav version for compliance reasons
 clamscan --version
 

--- a/Containers/clamav/supervisord.conf
+++ b/Containers/clamav/supervisord.conf
@@ -21,3 +21,10 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 command=clamd --foreground --config-file=/tmp/clamd.conf
+
+[program:milter]
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+command=clamav-milter --foreground --config-file=/tmp/clamv-milter-conf


### PR DESCRIPTION
This contains installing and configuring the clamav-milter process and then starting it with supervisord.

TODO: start milter only when the stalwart community container is activated

This is a requirement for changing the stalwart milter port to 7357 and mitigating https://github.com/docjyJ/aio-stalwart/issues/82