### PR TITLE
clamav: Add clamav-milter service

### DIFF
--- a/Containers/clamav/Dockerfile
+++ b/Containers/clamav/Dockerfile
@@ -16,7 +16,8 @@ RUN set -ex; \
     sed -i "s|Example| |g" /etc/clamav/clamav-milter.conf; \
     sed -i "s|#\?MilterSocket inet:7357|MilterSocket inet:7357|g" /etc/clamav/clamav-milter.conf; \
     sed -i "s|#\?ClamdSocket unix:/run/clamav/clamd.sock|ClamdSocket unix:/tmp/clamd.sock|g" /etc/clamav/clamav-milter.conf; \
-    sed -i "s|#\?AddHeader Replace|AddHeader Add|g" /etc/clamav/clamav-milter.conf
+    sed -i "s|#\?AddHeader Replace|AddHeader Add|g" /etc/clamav/clamav-milter.conf; \
+    sed -i "s|#\?Foreground yes|Foreground yes|g" /etc/clamav/clamav-milter.conf
 
 COPY --chmod=775 start.sh /start.sh
 COPY --chmod=775 healthcheck.sh /healthcheck.sh

--- a/Containers/clamav/supervisord.conf
+++ b/Containers/clamav/supervisord.conf
@@ -27,4 +27,4 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
-command=clamav-milter --foreground --config-file=/etc/clamav/clamav-milter.conf
+command=clamav-milter --config-file=/etc/clamav/clamav-milter.conf


### PR DESCRIPTION
- Mitigating https://github.com/docjyJ/aio-stalwart/issues/82#issuecomment-3402417699
- Close https://github.com/nextcloud/all-in-one/discussions/6981

Content:
- Add clamav-milter package from distro source
- Using example configuration as basis and modifying listening port, clamd socket and adding X-Virus-Status header for tracability
- Starting clamav-milter service with supervisord