### PR TITLE
mastercontainer: bind 8000 only to 127.0.0.1

### DIFF
--- a/Containers/mastercontainer/mastercontainer.conf
+++ b/Containers/mastercontainer/mastercontainer.conf
@@ -7,8 +7,8 @@ Listen 8080 https
 </Files>
 
 # Http host
-<VirtualHost *:8000>
-    ServerName localhost
+<VirtualHost 127.0.0.1:8000>
+    ServerName 127.0.0.1
 
     # Add error log
     CustomLog /proc/self/fd/1 proxy


### PR DESCRIPTION
https://github.com/nextcloud/all-in-one/pull/6949#discussion_r2437156994

In my test it worked.