### PR TITLE
update nextcloud-exporter image tag to 0.9.0

### DIFF
--- a/community-containers/nextcloud-exporter/nextcloud-exporter.json
+++ b/community-containers/nextcloud-exporter/nextcloud-exporter.json
@@ -5,7 +5,7 @@
             "display_name": "Prometheus Nextcloud Exporter",
             "documentation": "https://github.com/nextcloud/all-in-one/tree/main/community-containers/nextcloud-exporter",
             "image": "ghcr.io/xperimental/nextcloud-exporter",
-            "image_tag": "0.8.0",
+            "image_tag": "0.9.0",
             "internal_port": "9205",
             "restart": "unless-stopped",
             "ports": [


### PR DESCRIPTION
Update the image to the latest version.

Tested and works as expected.

Changelog: https://github.com/xperimental/nextcloud-exporter/releases/tag/v0.9.0