### PR TITLE
clamav: change clamav-milter OnInfected Action to Reject

### DIFF
--- a/Containers/clamav/Dockerfile
+++ b/Containers/clamav/Dockerfile
@@ -17,6 +17,7 @@ RUN set -ex; \
     sed -i "s|Example| |g" /etc/clamav/clamav-milter.conf; \
     sed -i "s|#\?MilterSocket inet:7357|MilterSocket inet:7357|g" /etc/clamav/clamav-milter.conf; \
     sed -i "s|#\?ClamdSocket unix:/run/clamav/clamd.sock|ClamdSocket unix:/tmp/clamd.sock|g" /etc/clamav/clamav-milter.conf; \
+    sed -i "s|#\?OnInfected Quarantine|OnInfected Reject|g" /etc/clamav/clamav-milter.conf; \
     sed -i "s|#\?AddHeader Replace|AddHeader Add|g" /etc/clamav/clamav-milter.conf; \
     sed -i "s|#\?Foreground yes|Foreground yes|g" /etc/clamav/clamav-milter.conf
 


### PR DESCRIPTION
During testing the Beta with eicar virus test files, I noticed that Stalwart is not reliable respecting the Quarantine from clamav-milter. Even though the Clamav scanner was able to detect the test virus every time. 
Therefore, I recommend changing the OnInfected Action to Reject, what is in line with the configuration of Nextcloud Antivirus plugin which also rejects infected uploads. 