### PR TITLE
Replace grep -P with grep -E to avoid illegal instruction on non-AVX …

### DIFF
--- a/Containers/talk/start.sh
+++ b/Containers/talk/start.sh
@@ -19,7 +19,7 @@ elif [ -z "$INTERNAL_SECRET" ]; then
 fi
 
 set -x
-IPv4_ADDRESS_TALK_RELAY="$(hostname -i | grep -oP '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+IPv4_ADDRESS_TALK_RELAY="$(hostname -i | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
 # shellcheck disable=SC2153
 IPv4_ADDRESS_TALK="$(dig "$TALK_HOST" IN A +short +search | grep '^[0-9.]\+$' | sort | head -n1)"
 # shellcheck disable=SC2153


### PR DESCRIPTION
### Summary
`grep -P` triggers PCRE JIT which depends on AVX CPU instructions. On systems without AVX
(for example many VMware ESXi hosts and older Xeon CPUs), this results in a crash during
Talk relay startup:

```
Illegal instruction (core dumped)
```

This prevents the Talk High Performance Backend from running on those environments.

---

### What this PR changes
Replaces:

```
grep -oP
```

with:

```
grep -oE
```

in `Containers/talk/start.sh`.

---

### Why this works
`grep -E` uses the **POSIX Extended Regular Expression** engine, which:

- does **not** use PCRE JIT
- does **not** require AVX CPU instructions
- produces **identical matching behavior** for this pattern

This makes the script compatible with a wider range of hardware.

---

### Result
Talk relay startup now works correctly on:

- VMware ESXi hosts
- Older Xeon CPUs without AVX


There is:

- **No functional behavior change**
- **No performance impact**
- **No configuration change required**

---

### Testing
Verified on:

- ESXi 7.0.0 host
- Intel Xeon CPU (no AVX support)
- Nextcloud AIO Talk container starts and runs normally.