### PR TITLE
docker-image-prune: only remove image with `label=org.label-schema.vendor=Nextcloud`

### DIFF
--- a/Containers/mastercontainer/cron.sh
+++ b/Containers/mastercontainer/cron.sh
@@ -60,7 +60,7 @@ while true; do
     fi
 
     # Remove dangling images
-    sudo -u www-data docker image prune --force
+    sudo -u www-data docker image prune --filter "label=org.label-schema.vendor=Nextcloud" --force
 
     # Check for available free space
     sudo -u www-data php /var/www/docker-aio/php/src/Cron/CheckFreeDiskSpace.php


### PR DESCRIPTION
- Close https://github.com/nextcloud/all-in-one/issues/6410