### PR TITLE
ConnectContainerIdToNetwork: remove `CheckDuplicate` as it is deprecated

### DIFF
--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -837,7 +837,6 @@ readonly class DockerActionManager {
                     [
                         'json' => [
                             'Name' => $network,
-                            'CheckDuplicate' => true,
                             'Driver' => 'bridge',
                             'Internal' => false,
                         ]


### PR DESCRIPTION
- Address https://github.com/nextcloud/all-in-one/pull/7098#issuecomment-3515666537