### PR TITLE
`ConnectContainerIdToNetwork`: switch from `Aliases` to  `DNSNames`

### DIFF
--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -860,7 +860,7 @@ readonly class DockerActionManager {
         );
         $jsonPayload = ['Container' => $id];
         if ($alias !== '') {
-            $jsonPayload['EndpointConfig'] = ['Aliases' => [$alias]];
+            $jsonPayload['EndpointConfig'] = ['DNSNames ' => [$alias]];
         }
 
         try {


### PR DESCRIPTION
As mentioned here: https://github.com/nextcloud/app_api/pull/699#issue-3624297168