### PR TITLE
fix whiteboard recording chrome #3

### DIFF
--- a/Containers/whiteboard/Dockerfile
+++ b/Containers/whiteboard/Dockerfile
@@ -5,6 +5,7 @@ FROM ghcr.io/nextcloud-releases/whiteboard:v1.4.1
 USER root
 RUN set -ex; \
     apk add --no-cache bash; \
+    chmod 777 -R /tmp; \
     if [ -f /usr/lib/chromium/chrome_crashpad_handler ] && [ ! -f /usr/lib/chromium/chrome_crashpad_handler.real ]; then \
         mv /usr/lib/chromium/chrome_crashpad_handler /usr/lib/chromium/chrome_crashpad_handler.real; \
         printf '%s\n' '#!/bin/sh' "exec /usr/lib/chromium/chrome_crashpad_handler.real --no-periodic-tasks --database=\"\${CRASHPAD_DATABASE:-/tmp/chrome-crashpad}\" \"\$@\"" >/usr/lib/chromium/chrome_crashpad_handler; \
@@ -17,7 +18,7 @@ COPY --chmod=775 healthcheck.sh /healthcheck.sh
 
 HEALTHCHECK CMD /healthcheck.sh
 
-WORKDIR /app
+WORKDIR /tmp
 
 ENTRYPOINT ["/start.sh"]
 


### PR DESCRIPTION
- running `apk upgrade --no-cache -a` and `chmod 777 -R /tmp` after pulling the upstream image that wipes out the secure `/tmp/chromium-runtime`/`chrome-crashpad` directories the upstream build prepares for Puppeteer, so Chromium never exposes its WS endpoint and all recording checks time out (10 s error dialog).
- only install `bash`, leave `/tmp` permissions alone, and only replace the crashpad handler when the upstream image hasn’t already patched it. Also keep the upstream working directory (`/app`), since the base image expects that.

Please have it a look and test @szaimen, thank you!
