### PR TITLE
Revert "ConnectContainerIdToNetwork: remove `CheckDuplicate` as it is deprecated"

### DIFF
--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -849,6 +849,7 @@ readonly class DockerActionManager {
                     [
                         'json' => [
                             'Name' => $network,
+                            'CheckDuplicate' => true,
                             'Driver' => 'bridge',
                             'Internal' => false,
                         ]


### PR DESCRIPTION
- Reverts nextcloud/all-in-one#7100
- Address https://github.com/nextcloud/all-in-one/issues/7096#issuecomment-3559820567