### PR TITLE
caddy-cc: only open port 443/tcp and forward port 443/udp to talk directly

### DIFF
--- a/community-containers/caddy/caddy.json
+++ b/community-containers/caddy/caddy.json
@@ -13,11 +13,6 @@
                   "ip_binding": "",
                   "port_number": "443",
                   "protocol": "tcp"
-                },
-                {
-                    "ip_binding": "",
-                    "port_number": "443",
-                    "protocol": "udp"
                 }
             ],
             "environment": [

--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -290,8 +290,8 @@ readonly class DockerActionManager {
                     }
                 } else if ($port === '%TALK_PORT%') {
                     $port = $this->configurationManager->GetTalkPort();
-                    // Skip publishing talk port if it is set to 443
-                    if ($port === '443') {
+                    // Skip publishing talk tcp port if it is set to 443
+                    if ($port === '443' && $protocol === 'tcp') {
                         continue;
                     }
                 }


### PR DESCRIPTION
- For https://github.com/szaimen/aio-caddy/issues/93
- Needs https://github.com/szaimen/aio-caddy/pull/99