### PR TITLE
fulltextsearch: disable memory locking

### DIFF
--- a/php/containers.json
+++ b/php/containers.json
@@ -794,7 +794,7 @@
       "environment": [
         "TZ=%TIMEZONE%",
         "ES_JAVA_OPTS=%FULLTEXTSEARCH_JAVA_OPTIONS%",
-        "bootstrap.memory_lock=true",
+        "bootstrap.memory_lock=false",
         "cluster.name=nextcloud-aio",
         "discovery.type=single-node",
         "logger.level=WARN",


### PR DESCRIPTION
Reason: in most docker deployments no swap is configured anyway.
- https://github.com/nextcloud/all-in-one/discussions/7204#discussioncomment-15089935