### PR TITLE
standardize ca-config

### DIFF
--- a/Containers/nextcloud/Dockerfile
+++ b/Containers/nextcloud/Dockerfile
@@ -251,6 +251,7 @@ RUN set -ex; \
     chmod 777 -R /usr/local/etc/php/conf.d && \
     chmod 777 -R /usr/local/etc/php-fpm.d && \
     chmod -R 777 /tmp; \
+    chmod -R 777 /etc/openldap; \
     \
     mkdir -p /nc-updater; \
     chmod -R 777 /nc-updater

--- a/Containers/nextcloud/config/postgres.config.php
+++ b/Containers/nextcloud/config/postgres.config.php
@@ -3,14 +3,14 @@ if (getenv('NEXTCLOUD_TRUSTED_CERTIFICATES_POSTGRES')) {
   $CONFIG = array(
     'pgsql_ssl' => array(
       'mode' => 'verify-ca',
-      'rootcert' => '/var/www/html/data/certificates/POSTGRES',
+      'rootcert' => '/var/www/html/data/certificates/ca-bundle.crt',
     ),
   );
 }
 if (getenv('NEXTCLOUD_TRUSTED_CERTIFICATES_MYSQL')) {
   $CONFIG = array(
     'dbdriveroptions' => array(
-      'PDO::MYSQL_ATTR_SSL_CA' => '/var/www/html/data/certificates/MYSQL',
+      'PDO::MYSQL_ATTR_SSL_CA' => '/var/www/html/data/certificates/ca-bundle.crt',
     ),
   );
 }

--- a/Containers/notify-push/start.sh
+++ b/Containers/notify-push/start.sh
@@ -68,10 +68,10 @@ fi
 
 # Postgres root cert
 if [ -f "/nextcloud/data/certificates/POSTGRES" ]; then
-    CERT_OPTIONS="?sslmode=verify-ca&sslrootcert=/nextcloud/data/certificates/POSTGRES"
+    CERT_OPTIONS="?sslmode=verify-ca&sslrootcert=/nextcloud/data/certificates/ca-bundle.crt"
 # Mysql root cert
 elif [ -f "/nextcloud/data/certificates/MYSQL" ]; then
-    CERT_OPTIONS="?sslmode=verify-ca&ssl-ca=/nextcloud/data/certificates/MYSQL"
+    CERT_OPTIONS="?sslmode=verify-ca&ssl-ca=/nextcloud/data/certificates/ca-bundle.crt"
 fi
 
 # Set sensitive values as env


### PR DESCRIPTION
- [x] TODO: use this feature: https://github.com/nextcloud/server/pull/52749 (Needs latest server releases, available at 11th december)
- [x] todo: configure ldap.conf to use the file automatically:

Add the directive: Add the TLS_CACERT directive pointing to your certificate file:
```ini
TLS_CACERT /path/to/your/ca.pem
TLS_REQCERT hard
```