### PR TITLE
nextcloud: fix configuration of `default_certificates_bundle_path` and allow to use bundle for mailer

### DIFF
--- a/Containers/nextcloud/config/certificates-bundle.config.php
+++ b/Containers/nextcloud/config/certificates-bundle.config.php
@@ -1,0 +1,5 @@
+<?php
+// Check if NEXTCLOUD_TRUSTED_CERTIFICATES_ are configured
+if (str_contains(implode(' ', array_keys(getenv())), 'NEXTCLOUD_TRUSTED_CERTIFICATES_')) {
+  $CONFIG['default_certificates_bundle_path'] = '/var/www/html/data/certificates/ca-bundle.crt';
+}

--- a/Containers/nextcloud/config/smtp.config.php
+++ b/Containers/nextcloud/config/smtp.config.php
@@ -18,3 +18,14 @@ if (getenv('SMTP_HOST') && getenv('MAIL_FROM_ADDRESS') && getenv('MAIL_DOMAIN'))
       $CONFIG['mail_smtppassword'] = '';
   }
 }
+
+if (getenv('NEXTCLOUD_TRUSTED_CERTIFICATES_MAILER')) {
+  $CONFIG = array(
+    'mail_smtpstreamoptions' => array(
+      'ssl' => array(
+        'verify_peer_name' => false,
+        'cafile' => '/var/www/html/data/certificates/ca-bundle.crt',
+      )
+    )
+  );
+}

--- a/Containers/nextcloud/entrypoint.sh
+++ b/Containers/nextcloud/entrypoint.sh
@@ -20,13 +20,6 @@ run_upgrade_if_needed_due_to_app_update() {
     fi
 }
 
-set_global_ca_bundle_path() {
-    # Only run if env is set
-    if env | grep -q NEXTCLOUD_TRUSTED_CERTIFICATES_; then
-        php /var/www/html/occ config:system:set default_certificates_bundle_path --value="$CERTIFICATE_BUNDLE"
-    fi
-}
-
 # Create cert bundle
 if env | grep -q NEXTCLOUD_TRUSTED_CERTIFICATES_; then
 
@@ -246,8 +239,6 @@ if ! [ -f "$NEXTCLOUD_DATA_DIR/skip.update" ]; then
 
             run_upgrade_if_needed_due_to_app_update
 
-            set_global_ca_bundle_path
-
             php /var/www/html/occ maintenance:mode --off
 
             echo "Getting and backing up the status of apps for later; this might take a while..."
@@ -380,8 +371,6 @@ EOF
 
             # Try to force generation of appdata dir:
             php /var/www/html/occ maintenance:repair
-
-            set_global_ca_bundle_path
 
             if [ -z "$OBJECTSTORE_S3_BUCKET" ] && [ -z "$OBJECTSTORE_SWIFT_URL" ]; then
                 max_retries=10
@@ -598,8 +587,6 @@ else
 fi
 
 run_upgrade_if_needed_due_to_app_update
-
-set_global_ca_bundle_path
 
 if [ -z "$OBJECTSTORE_S3_BUCKET" ] && [ -z "$OBJECTSTORE_SWIFT_URL" ]; then
     # Check if appdata is present


### PR DESCRIPTION
- Follow-up to https://github.com/nextcloud/all-in-one/pull/7217