### PR TITLE
Revert "DockerActionManager: disable seccomp policy for borgbackup container"

### DIFF
--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -376,11 +376,6 @@ readonly class DockerActionManager {
 
         // Special things for the backup container which should not be exposed in the containers.json
         if (str_starts_with($container->GetIdentifier(), 'nextcloud-aio-borgbackup')) {
-            // Disable seccomp policy if seccomp is enabled in the kernel to fix issues like https://github.com/nextcloud/all-in-one/issues/7308
-            if (!$this->configurationManager->isSeccompDisabled()) {
-                $requestBody['HostConfig']['SecurityOpt'] = ["apparmor:unconfined", "label:disable", "seccomp:unconfined"];
-            }
-
             // Additional backup directories
             foreach ($this->getAllBackupVolumes() as $additionalBackupVolumes) {
                 if ($additionalBackupVolumes !== '') {


### PR DESCRIPTION
- Reverts nextcloud/all-in-one#7414
- Reason: this does not seem to work based on https://github.com/nextcloud/all-in-one/pull/7414#issuecomment-3751335638.

