### PR TITLE
refactor(app): modernize and tidy up public entrypoint

### DIFF
--- a/php/public/index.php
+++ b/php/public/index.php
@@ -189,8 +189,9 @@ $app->get('/containers', function (Request $request, Response $response, array $
         'skip_domain_validation' => $configurationManager->shouldDomainValidationBeSkipped($skip_domain_validation),
         'bypass_container_update' => $bypass_container_update,
     ]);
-})->setName('profile');
-$app->get('/login', function (Request $request, Response $response, array $args) use ($container) {
+});
+
+// Login
 $app->get('/login', function (Request $request, Response $response, array $args) use ($container): Response {
     $view = Twig::fromRequest($request);
     /** @var \AIO\Docker\DockerActionManager $dockerActionManager */

--- a/php/public/index.php
+++ b/php/public/index.php
@@ -35,8 +35,7 @@ AppFactory::setContainer($container);
 $app = AppFactory::create();
 $responseFactory = $app->getResponseFactory();
 
-// Register Middleware On Container
-$container->set(Guard::class, function () use ($responseFactory) {
+$container->set(Guard::class, function () use ($responseFactory): Guard {
     $guard = new Guard($responseFactory);
     $guard->setPersistentTokenMode(true);
     return $guard;
@@ -72,7 +71,7 @@ $app->post('/api/auth/logout', AIO\Controller\LoginController::class . ':Logout'
 $app->post('/api/configuration', \AIO\Controller\ConfigurationController::class . ':SetConfig');
 
 // Views
-$app->get('/containers', function (Request $request, Response $response, array $args) use ($container) {
+$app->get('/containers', function (Request $request, Response $response, array $args) use ($container): Response {
     $view = Twig::fromRequest($request);
     $view->addExtension(new \AIO\Twig\ClassExtension());
     /** @var \AIO\Data\ConfigurationManager $configurationManager */
@@ -143,6 +142,7 @@ $app->get('/containers', function (Request $request, Response $response, array $
     ]);
 })->setName('profile');
 $app->get('/login', function (Request $request, Response $response, array $args) use ($container) {
+$app->get('/login', function (Request $request, Response $response, array $args) use ($container): Response {
     $view = Twig::fromRequest($request);
     /** @var \AIO\Docker\DockerActionManager $dockerActionManager */
     $dockerActionManager = $container->get(\AIO\Docker\DockerActionManager::class);
@@ -150,7 +150,9 @@ $app->get('/login', function (Request $request, Response $response, array $args)
         'is_login_allowed' => $dockerActionManager->isLoginAllowed(),
     ]);
 });
-$app->get('/setup', function (Request $request, Response $response, array $args) use ($container) {
+
+// Setup
+$app->get('/setup', function (Request $request, Response $response, array $args) use ($container): Response {
     $view = Twig::fromRequest($request);
     /** @var \AIO\Data\Setup $setup */
     $setup = $container->get(\AIO\Data\Setup::class);
@@ -171,8 +173,10 @@ $app->get('/setup', function (Request $request, Response $response, array $args)
     );
 });
 
-// Auth Redirector
-$app->get('/', function (\Psr\Http\Message\RequestInterface $request, Response $response, array $args) use ($container) {
+//-------------------------------------------------
+// Root Redirector
+//-------------------------------------------------
+$app->get('/', function (Request $request, Response $response, array $args) use ($container): Response {
     /** @var \AIO\Auth\AuthManager $authManager */
     $authManager = $container->get(\AIO\Auth\AuthManager::class);
 

--- a/php/public/index.php
+++ b/php/public/index.php
@@ -21,21 +21,21 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 // Configuration Constants
 //-------------------------------------------------
 const AIO_MEMORY_LIMIT         = '2048M';
-const AIO_MAX_EXECUTION_TIME   = '7200';    // (2h) in case of a very slow internet connection
-const AIO_SESSION_MAX_LIFETIME = '86400';   // (24h)
-const AIO_COOKIE_LIFETIME      = '0';       // Auto logout on browser close
-const AIO_LOG_ERRORS_MAX_LEN   = '0';       // Log whole log messages
+const AIO_MAX_EXECUTION_TIME   = '7200';    // (2h) Supports slow networks and long operations
+const AIO_COOKIE_LIFETIME      = '0';       // Session cookie expires with browser close
+const AIO_SESSION_MAX_LIFETIME = '86400';   // (24h) Maximum admin session length
+const AIO_LOG_ERRORS_MAX_LEN   = '0';       // Log full-length errors for troubleshooting
 const AIO_TWIG_CACHE_PATH      = false;     // e.g., __DIR__ . '/../var/twig-cache'
-const AIO_DISPLAY_ERRORS       = false;
+const AIO_DISPLAY_ERRORS       = false;	    // Do not directly expose errors to site visitors
 
 //-------------------------------------------------
 // PHP Settings
 //-------------------------------------------------
 ini_set('memory_limit',            AIO_MEMORY_LIMIT);
-ini_set('max_execution_time',      AIO_MAX_EXECUTION_TIME);
-ini_set('session.cookie_lifetime', AIO_COOKIE_LIFETIME);
-ini_set('session.gc_maxlifetime',  AIO_SESSION_MAX_LIFETIME);
-ini_set('log_errors_max_len',      AIO_LOG_ERRORS_MAX_LEN);
+ini_set('max_execution_time',      AIO_MAX_EXECUTION_TIME); // Prevent timeouts on slow networks
+ini_set('session.cookie_lifetime', AIO_COOKIE_LIFETIME); // Auto-logout on browser close
+ini_set('session.gc_maxlifetime',  AIO_SESSION_MAX_LIFETIME); // 24h session duration
+ini_set('log_errors_max_len',      AIO_LOG_ERRORS_MAX_LEN); // Full error logs
 
 //-------------------------------------------------
 // Dependency Injection
@@ -43,7 +43,7 @@ ini_set('log_errors_max_len',      AIO_LOG_ERRORS_MAX_LEN);
 $container = \AIO\DependencyInjection::GetContainer();
 AppFactory::setContainer($container);
 
-// Session directory depends on application config:
+// Session directory depends on application config
 $dataConst = $container->get(\AIO\Data\DataConst::class);
 ini_set('session.save_path', $dataConst->GetSessionDirectory());
 
@@ -164,7 +164,7 @@ $app->get('/containers', function (Request $request, Response $response, array $
         'is_dri_device_enabled' => $configurationManager->nextcloudEnableDriDevice,
         'is_nvidia_gpu_enabled' => $configurationManager->enableNvidiaGpu,
         'is_talk_recording_enabled' => $configurationManager->isTalkRecordingEnabled,
-	'is_docker_socket_proxy_enabled' => $configurationManager->isDockerSocketProxyEnabled,
+        'is_docker_socket_proxy_enabled' => $configurationManager->isDockerSocketProxyEnabled,
         'is_whiteboard_enabled' => $configurationManager->isWhiteboardEnabled,
         'is_backup_section_enabled' => !$configurationManager->disableBackupSection,
         // ---- Collabora Component ----

--- a/php/public/index.php
+++ b/php/public/index.php
@@ -144,7 +144,7 @@ $app->get('/containers', function (Request $request, Response $response, array $
         'containers' => (new \AIO\ContainerDefinitionFetcher($container->get(\AIO\Data\ConfigurationManager::class), $container))->FetchDefinition(),
         'was_start_button_clicked' => $configurationManager->wasStartButtonClicked,
         'has_update_available' => $dockerActionManager->isAnyUpdateAvailable(),
-        'is_mastercontainer_update_available' => ( $bypass_mastercontainer_update ? false : $dockerActionManager->IsMastercontainerUpdateAvailable() ),
+        'is_mastercontainer_update_available' => ( $bypassMastercontainerUpdate ? false : $dockerActionManager->IsMastercontainerUpdateAvailable() ),
         'automatic_updates' => $configurationManager->areAutomaticUpdatesEnabled(),
         // ---- Nextcloud Settings ----
         'nextcloud_password' => $configurationManager->getAndGenerateSecret('NEXTCLOUD_PASSWORD'),
@@ -190,8 +190,8 @@ $app->get('/containers', function (Request $request, Response $response, array $
         'community_containers' => $configurationManager->listAvailableCommunityContainers(),
         'community_containers_enabled' => $configurationManager->aioCommunityContainers,
         // ---- Admin Overrides ----
-        'skip_domain_validation' => $configurationManager->shouldDomainValidationBeSkipped($skip_domain_validation),
-        'bypass_container_update' => $bypass_container_update,
+        'skip_domain_validation' => $configurationManager->shouldDomainValidationBeSkipped($skipDomainValidation),
+        'bypass_container_update' => $bypassContainerUpdate,
     ]);
 });
 


### PR DESCRIPTION
Code was already pretty tidy; this just elevates it a bit more while cleaning up some minor tidbits.

- Refactored `php/public/index.php` for improved readability, maintainability, and adherence to best practices
- Introduced config constants; added type hints to all route closures
- Grouped variables by domain/context for template clarity
- Used route grouping with `$group` in Slim
- Switched to consistent namespace usage
- Added/updated comments
- Ensured root route type hints `ServerRequestInterface` rather than `RequestInterface`
- Dropped unused (and erroneous AFAIK) `profile` alias for the `/containers/` route

Not offended if you don't merge this, but I was reading through it anyhow. ;-)

Shouldn't be any breaking changes; largely cosmetic. If something is broken it's probably a typo on my part. ;-)