### PR TITLE
`CreateContainer`: also insert the max shutdown time into the container itself

### DIFF
--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -356,6 +356,11 @@ readonly class DockerActionManager {
 
         $requestBody['HostConfig']['Init'] = $container->init;
 
+        $maxShutDownTime = $container->maxShutdownTime;
+        if ($maxShutDownTime > 0) {
+            $requestBody['StopTimeout'] = $maxShutDownTime;
+        }
+
         $capAdds = $container->capAdd;
         if (count($capAdds) > 0) {
             $requestBody['HostConfig']['CapAdd'] = $capAdds;


### PR DESCRIPTION
- Close https://github.com/nextcloud/all-in-one/issues/7466