### PR TITLE
only allow to set `APACHE_ADDITIONAL_NETWORK` via environmental variable and do not restore it on backup restore

### DIFF
--- a/php/src/Data/ConfigurationManager.php
+++ b/php/src/Data/ConfigurationManager.php
@@ -263,11 +263,6 @@ class ConfigurationManager
         set { $this->set('collabora_seccomp_disabled', $value); }
     }
 
-    public string $apacheAdditionalNetwork {
-        get => $this->getEnvironmentalVariableOrConfig('APACHE_ADDITIONAL_NETWORK', 'apache_additional_network', '');
-        set { $this->set('apache_additional_network', $value); }
-    }
-
     public bool $disableBackupSection {
         get => $this->booleanize($this->getEnvironmentalVariableOrConfig('AIO_DISABLE_BACKUP_SECTION', 'disable_backup_section', ''));
         set { $this->set('disable_backup_section', $value); }
@@ -852,6 +847,14 @@ class ConfigurationManager
             return true;
         }
         return false;
+    }
+
+    public function getApacheAdditionalNetwork() : string {
+        $network = getenv('APACHE_ADDITIONAL_NETWORK');
+        if (is_string($network)) {
+            return trim($network);
+        }
+        return '';
     }
 
     public function getNextcloudStartupApps() : string {

--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -843,7 +843,7 @@ readonly class DockerActionManager {
         $this->ConnectContainerIdToNetwork($container->identifier, $container->internalPorts, alias: $alias);
 
         if ($container->identifier === 'nextcloud-aio-apache' || $container->identifier === 'nextcloud-aio-domaincheck') {
-            $apacheAdditionalNetwork = $this->configurationManager->apacheAdditionalNetwork;
+            $apacheAdditionalNetwork = $this->configurationManager->getApacheAdditionalNetwork();
             if ($apacheAdditionalNetwork !== '') {
                 $this->ConnectContainerIdToNetwork($container->identifier, $container->internalPorts, $apacheAdditionalNetwork, false, $alias);
             }


### PR DESCRIPTION
Try to prevent cases like https://help.nextcloud.com/t/cant-reach-my-nextcloud-after-restore/239493