### PR TITLE
Wrap ConfigurationController#SetConfig into a "transaction"

### DIFF
--- a/php/src/Controller/ConfigurationController.php
+++ b/php/src/Controller/ConfigurationController.php
@@ -17,6 +17,7 @@ readonly class ConfigurationController {
 
     public function SetConfig(Request $request, Response $response, array $args): Response {
         try {
+            $this->configurationManager->startTransaction();
             if (isset($request->getParsedBody()['domain'])) {
                 $domain = $request->getParsedBody()['domain'] ?? '';
                 $skipDomainValidation = isset($request->getParsedBody()['skip_domain_validation']);
@@ -137,6 +138,8 @@ readonly class ConfigurationController {
         } catch (InvalidSettingConfigurationException $ex) {
             $response->getBody()->write($ex->getMessage());
             return $response->withStatus(422);
+        } finally {
+            $this->configurationManager->commitTransaction();
         }
     }
 }


### PR DESCRIPTION
This avoids a lot of subsequent writes and reads from the file system, because now only commitTransaction() actually writes the config file.


* Close #7500 
* [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
