### PR TITLE
Set error level to 1 in psalm configuration

### DIFF
--- a/php/psalm-baseline.xml
+++ b/php/psalm-baseline.xml
@@ -1,2 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.14.3@d0b040a91f280f071c1abcb1b77ce3822058725a"/>
+<files psalm-version="6.14.3@d0b040a91f280f071c1abcb1b77ce3822058725a">
+  <file src="public/index.php">
+    <MixedArgument>
+      <code><![CDATA[$container->get(Guard::class)]]></code>
+      <code><![CDATA[$container->get(\AIO\Auth\AuthManager::class)]]></code>
+      <code><![CDATA[$container->get(\AIO\Data\ConfigurationManager::class)]]></code>
+    </MixedArgument>
+  </file>
+  <file src="src/ContainerDefinitionFetcher.php">
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$backupVolumes]]></code>
+      <code><![CDATA[$capAdd]]></code>
+      <code><![CDATA[$devices]]></code>
+    </MixedArgumentTypeCoercion>
+  </file>
+  <file src="src/Controller/ConfigurationController.php">
+    <PossiblyNullIterator>
+      <code><![CDATA[$request->getParsedBody()]]></code>
+    </PossiblyNullIterator>
+  </file>
+  <file src="src/DependencyInjection.php">
+    <MixedArgument>
+      <code><![CDATA[$container->get(DockerHubManager::class)]]></code>
+      <code><![CDATA[$container->get(GitHubContainerRegistryManager::class)]]></code>
+      <code><![CDATA[$container->get(\AIO\Auth\PasswordGenerator::class)]]></code>
+      <code><![CDATA[$container->get(\AIO\ContainerDefinitionFetcher::class)]]></code>
+      <code><![CDATA[$container->get(\AIO\Data\ConfigurationManager::class)]]></code>
+      <code><![CDATA[$container->get(\AIO\Data\ConfigurationManager::class)]]></code>
+      <code><![CDATA[$container->get(\AIO\Data\ConfigurationManager::class)]]></code>
+    </MixedArgument>
+  </file>
+  <file src="src/Docker/DockerActionManager.php">
+    <MixedOperand>
+      <code><![CDATA[$output['Config']['Image']]]></code>
+    </MixedOperand>
+  </file>
+</files>

--- a/php/psalm.xml
+++ b/php/psalm.xml
@@ -6,6 +6,7 @@
 	errorBaseline="psalm-baseline.xml"
 	findUnusedBaselineEntry="true"
 	findUnusedCode="false"
+	errorLevel="2"
 >
 	<projectFiles>
 		<directory name="templates"/>

--- a/php/psalm.xml
+++ b/php/psalm.xml
@@ -6,7 +6,7 @@
 	errorBaseline="psalm-baseline.xml"
 	findUnusedBaselineEntry="true"
 	findUnusedCode="false"
-	errorLevel="2"
+	errorLevel="1"
 >
 	<projectFiles>
 		<directory name="templates"/>

--- a/php/src/ContainerDefinitionFetcher.php
+++ b/php/src/ContainerDefinitionFetcher.php
@@ -108,9 +108,9 @@ readonly class ContainerDefinitionFetcher {
                 foreach ($entry['ports'] as $value) {
                     $ports->AddPort(
                         new ContainerPort(
-                            $value['port_number'],
-                            $value['ip_binding'],
-                            $value['protocol']
+                            (string) $value['port_number'],
+                            (string) $value['ip_binding'],
+                            (string) $value['protocol']
                         )
                     );
                 }
@@ -155,9 +155,9 @@ readonly class ContainerDefinitionFetcher {
                     }
                     $volumes->AddVolume(
                         new ContainerVolume(
-                            $value['source'],
-                            $value['destination'],
-                            $value['writeable']
+                            (string) $value['source'],
+                            (string) $value['destination'],
+                            (bool) $value['writeable']
                         )
                     );
                 }
@@ -335,9 +335,9 @@ readonly class ContainerDefinitionFetcher {
             }
 
             $containers[] = new Container(
-                $entry['container_name'],
+                (string) $entry['container_name'],
                 $displayName,
-                $entry['image'],
+                (string) $entry['image'],
                 $restartPolicy,
                 $maxShutdownTime,
                 $ports,

--- a/php/src/Controller/ConfigurationController.php
+++ b/php/src/Controller/ConfigurationController.php
@@ -114,7 +114,6 @@ readonly class ConfigurationController {
                 $cc = $this->configurationManager->listAvailableCommunityContainers();
                 $enabledCC = [];
                 /**
-                 * @psalm-suppress PossiblyNullIterator
                  * @psalm-var string $item
                  */
                 foreach ($request->getParsedBody() as $item) {

--- a/php/src/Data/ConfigurationManager.php
+++ b/php/src/Data/ConfigurationManager.php
@@ -341,10 +341,10 @@ class ConfigurationManager
         }
 
         if ($secretId === 'BORGBACKUP_PASSWORD' && !file_exists(DataConst::GetBackupSecretFile())) {
-            $this->doubleSafeBackupSecret($secrets[$secretId]);
+            $this->doubleSafeBackupSecret((string)$secrets[$secretId]);
         }
 
-        return $secrets[$secretId];
+        return (string)$secrets[$secretId];
     }
 
     public function getRegisteredSecret(string $secretId) : string {
@@ -704,7 +704,7 @@ class ConfigurationManager
             if ($configValue === '') {
                 return $defaultValue;
             }
-            return $configValue;
+            return (string) $configValue;
         }
 
         if (file_exists(DataConst::GetConfigFile())) {

--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -57,7 +57,7 @@ readonly class DockerActionManager {
         /** @var array */
         $responseBody = json_decode((string)$response->getBody(), true, 512, JSON_THROW_ON_ERROR);
 
-        if ($responseBody['State']['Running'] === true) {
+        if ($responseBody['State']['Running'] ?? false === true) {
             return ContainerState::Running;
         } else {
             return ContainerState::Stopped;
@@ -78,7 +78,7 @@ readonly class DockerActionManager {
         /** @var array */
         $responseBody = json_decode((string)$response->getBody(), true, 512, JSON_THROW_ON_ERROR);
 
-        if ($responseBody['State']['Restarting'] === true) {
+        if ($responseBody['State']['Restarting'] ?? false === true) {
             return ContainerState::Restarting;
         } else {
             return ContainerState::NotRestarting;
@@ -656,11 +656,11 @@ readonly class DockerActionManager {
         try {
             /** @var array */
             $output = json_decode($this->guzzleClient->get($url)->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
-            $imageNameArray = explode(':', $output['Config']['Image']);
+            $imageNameArray = explode(':', (string) $output['Config']['Image']);
             if (count($imageNameArray) === 2) {
                 $imageName = $imageNameArray[0];
             } else {
-                error_log("No tag was found when getting the current channel. You probably did not follow the documentation correctly. Changing the imageName to the default " . $output['Config']['Image']);
+                error_log("No tag was found when getting the current channel. You probably did not follow the documentation correctly. Changing the imageName to the default " . (string) $output['Config']['Image']);
                 $imageName = (string) $output['Config']['Image'];
             }
             apcu_add($cacheKey, $imageName);
@@ -685,7 +685,7 @@ readonly class DockerActionManager {
         try {
             /** @var array */
             $output = json_decode($this->guzzleClient->get($url)->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
-            $tagArray = explode(':', $output['Config']['Image']);
+            $tagArray = explode(':', (string) $output['Config']['Image']);
             if (count($tagArray) === 2) {
                 $tag = $tagArray[1];
             } else {
@@ -898,7 +898,7 @@ readonly class DockerActionManager {
         $responseBody = json_decode((string)$response->getBody(), true, 512, JSON_THROW_ON_ERROR);
 
         /** @var null|int */
-        $exitCode = $responseBody['State']['ExitCode'];
+        $exitCode = $responseBody['State']['ExitCode'] ?? null;
         if (is_int($exitCode)) {
             return $exitCode;
         } else {
@@ -922,7 +922,7 @@ readonly class DockerActionManager {
         $responseBody = json_decode((string)$response->getBody(), true, 512, JSON_THROW_ON_ERROR);
 
         /** @var null|int */
-        $exitCode = $responseBody['State']['ExitCode'];
+        $exitCode = $responseBody['State']['ExitCode'] ?? null;
         if (is_int($exitCode)) {
             return $exitCode;
         } else {


### PR DESCRIPTION
Todo: 
- [ ] todo: as discussed, only keep type casts and actually useful type hints
- [ ] revert psalm level 1