### PR TITLE
redis and apache: delete openssl after using it

### DIFF
--- a/Containers/apache/Dockerfile
+++ b/Containers/apache/Dockerfile
@@ -79,7 +79,8 @@ RUN set -ex; \
     chmod 777 -R /usr/local/apache2/logs; \
     rm -rf /usr/local/apache2/cgi-bin/; \
     \
-    echo "root:$(openssl rand -base64 12)" | chpasswd
+    echo "root:$(openssl rand -base64 12)" | chpasswd; \
+    apk --no-cache del openssl
 
 USER 33
 

--- a/Containers/redis/Dockerfile
+++ b/Containers/redis/Dockerfile
@@ -10,6 +10,7 @@ RUN set -ex; \
     \
 # Give root a random password
     echo "root:$(openssl rand -base64 12)" | chpasswd; \
+    apk --no-cache del openssl; \
     \
 # Get rid of unused binaries
     rm -f /usr/local/bin/gosu;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->
