### PR TITLE
aio-interface: 404 error handler for less app output pollution

### DIFF
--- a/php/public/index.php
+++ b/php/public/index.php
@@ -197,4 +197,13 @@ $app->get('/', function (\Psr\Http\Message\RequestInterface $request, Response $
 
 $errorMiddleware = $app->addErrorMiddleware(false, true, true);
 
+// Set a custom Not Found handler, which doesn't pollute the app output with 404 errors.
+$errorMiddleware->setErrorHandler(
+    \Slim\Exception\HttpNotFoundException::class,
+    function (Request $request, Throwable $exception, bool $displayErrorDetails) use ($app) {
+        $response = $app->getResponseFactory()->createResponse();
+        $response->getBody()->write('Not Found');
+        return $response->withStatus(404);
+    });
+
 $app->run();


### PR DESCRIPTION
This introduces a custom error handler for 404 responses, so they don't show up as exceptions in the process output anymore.