### PR TITLE
readme: fix typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -634,7 +634,7 @@ Additionally, you might need to create a custom user script to start all sibling
 sleep 120
 
 # Execute the actual command
-docker exec --env START_CONTAINERS=1 nextcloud-aio-mastercontainer /daily-backup.sh`
+docker exec --env START_CONTAINERS=1 nextcloud-aio-mastercontainer /daily-backup.sh
 ```
 
 Apart from that, the installation of AIO should work like on "normal" Linux. So refer to the Linux instructions for installation.


### PR DESCRIPTION
Erroneous backtick (`) at the end of the Unraid script command.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->
