### PR TITLE
docs: add warnings about IP address and self-signed certificate limitations

### DIFF
--- a/local-instance.md
+++ b/local-instance.md
@@ -1,4 +1,10 @@
 # Local instance
+
+> [!WARNING]
+> AIO requires a **real domain name** and a **valid TLS certificate** to function correctly.
+> Accessing Nextcloud via a plain IP address or a self-signed certificate is **not supported**.
+> The options below describe how to satisfy these requirements while keeping Nextcloud local.
+
 It is possible due to several reasons that you do not want or cannot open Nextcloud to the public internet. Perhaps you were hoping to access AIO directly from an `ip.add.r.ess` (unsupported) or without a valid domain.  However, AIO requires a valid certificate to work correctly. Below is discussed how you can achieve both: Having a valid certificate for Nextcloud and only using it locally.
 
 ### Content

--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,10 @@ The steps below are written for Linux. For platform-specific guidance see:
 > [!IMPORTANT]  
 > These instructions assume there is no existing web server or reverse proxy (for example Apache, Nginx, Caddy, or Cloudflare Tunnel) that you intend to place in front of AIO. If you plan to run AIO behind an existing web server or reverse proxy, follow the AIO reverse proxy documentation: [Reverse proxy docs](https://github.com/nextcloud/all-in-one/blob/main/reverse-proxy.md)
 
+> [!WARNING]
+> AIO does **not** support IP addresses or self-signed certificates for the Nextcloud domain.
+> If you want a local-only instance, see [local-instance.md](./local-instance.md) before proceeding.
+
 You're encouraged to skim the attached [FAQ](#faq). While we've tried to make things straightforward, Nextcloud is a large and flexible platform. Reading the FAQ will save you time, particularly if edge cases come up.
 
 > [!TIP]  


### PR DESCRIPTION
Many users attempt to run Nextcloud AIO on a local network using an IP address or a self-signed certificate, only to discover this is unsupported after going through the setup process. I personally tried this too, even though i (quickly) read the README and Local-instance pages.

This PR makes the limitation more visible upfront so others won't make the same mistake.

## Changes
- `local-instance.md`: Added a `[!WARNING]` callout at the top of the page clearly stating that AIO requires a real domain name and a valid TLS certificate, and that IP addresses and self-signed certificates are not supported.
- `readme.md`: Added a `[!WARNING]` callout in the "How to use this?" section directing local-only users to `local-instance.md` before proceeding with setup.

## Motivation
The existing documentation mentions these limitations, but only in passing within a longer paragraph. Users who skim the docs (or jump straight to the setup steps) miss this entirely. The new callouts ensure the constraint is visible before any setup steps are taken.