### PR TITLE
talk-recording: fix missing characters in recorded video

### DIFF
--- a/Containers/talk-recording/Dockerfile
+++ b/Containers/talk-recording/Dockerfile
@@ -20,6 +20,9 @@ RUN set -ex; \
         xvfb \
         ffmpeg \
         firefox \
+        font-noto-all \
+        font-noto-cjk \
+        font-noto-cjk-extra \
         bind-tools \
         netcat-openbsd \
         git \


### PR DESCRIPTION
- Fixes #7692

The recording server uses a browser to join the call and records the browser UI, which renders text like the display name of users or the name of the Nextcloud instance. By default Firefox provides its own font but, even if broad, it still has limited character coverage, so [the unsupported characters are shown as the _.notdef_ glyph](https://en.wikipedia.org/wiki/Unicode_input#Grapheme_availability) (rectangular boxes).

Fortunately Firefox also uses more complete fonts automatically when they are available, so now the noto font, which seems to be the most complete font available in Alpine Linux, is installed and used instead.

Note that "font-noto-cjk" provides regular and bold fonts, while "font-noto-cjk-extra" provides all weights.

There is an additional noto package, "font-noto-emoji", which should cover all emojis. However, the normal fonts should already cover typical emojis, and it is unclear whether the emoji font would be used as a fallback for specific characters in  a text otherwise handled by another font, so it was not installed.