### PR TITLE
rp-docs: clarify AIO configuration for trusted reverse proxies

### DIFF
--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -1107,7 +1107,7 @@ After starting AIO, you should be able to access the AIO Interface via `https://
 Enter your domain in the AIO interface that you've used in the reverse proxy config and you should be done. Please do not forget to open/forward port `3478/TCP` and `3478/UDP` in your firewall/router for the Talk container!
 
 ### 5. Optional: Configure AIO for reverse proxies that connect to nextcloud not using localhost nor 127.0.0.1
-If your reverse proxy connects to nextcloud not using localhost or 127.0.0.1, you must add said IP as trusted proxy in the env file. 
+If your reverse proxy connects to nextcloud not using localhost or 127.0.0.1, you must add said IP as trusted proxy to the installation. See the step below:
 
 Add the IP it uses connect to AIO to the Nextcloud trusted_proxies like this:
 


### PR DESCRIPTION
Unfortunately I was unable to finish the discussion here:
https://help.nextcloud.com/t/trusted-reverse-proxies-for-from-private-ip-range/241533
so I hope I am not missing or misunderstanding something. 

IMHO the word "not" in this is wrong:
`*: The IP address it uses to connect to AIO is not in a private IP range such as these: 127.0.0.0/8,192.168.0.0/16,172.16.0.0/12,10.0.0.0/8,100.64.0.0/10,fd00::/8,::1/128`

I don't even know what it should be if not in a private IP range? A public IP like 80.80.80.1?

Either way I tested it with my instance.

I have AIO running on 10.0.58.2. The reverse proxy on 10.0.58.10 proxy passes the traffic to 10.0.58.2:11000. This works fine, but AIO thinks that all external connections are the NGINX proxy 10.0.58.10

Not following this doc, but instead running 

> sudo docker exec --user www-data -it nextcloud-aio-nextcloud php occ config:system:set trusted_proxies 2 --value="10.0.58.10"

did solve this issue. 

Based on these assumptions I made this PR. 