### PR TITLE
Exclude /lost+found from rsync

### DIFF
--- a/Containers/nextcloud/upgrade.exclude
+++ b/Containers/nextcloud/upgrade.exclude
@@ -3,3 +3,4 @@
 /custom_apps/
 /themes/
 /version.php
+/lost+found


### PR DESCRIPTION
This prevents an error that sometimes leads to irritation (even though it's harmless)