### PR TITLE
Tweak Collabora params to disable background update checks and notifications

### DIFF
--- a/php/containers.json
+++ b/php/containers.json
@@ -395,7 +395,6 @@
         "collabora"
       ],
       "cap_add": [
-        "MKNOD",
         "SYS_ADMIN",
         "SYS_CHROOT",
         "FOWNER",


### PR DESCRIPTION
When a new Collabora Online version is released, a notification appears in the document editor from time to time. The problem is that most of the time, those notifications are simply unactionable (and therefore annoying), because users cannot upgrade to a newer Collabora version than the one shipped with AIO.
While looking into disabling them, I've discovered that [Collabora automatically checks for updates in background every 10 hours by default](https://github.com/CollaboraOnline/online/blob/main/coolwsd.xml.in#L48) (`fetch_update_check` option). Since we are turning off update notifications, I think it's a good idea to disable those checks too (note that the documentation in coolwsd.xml doesn't explicitly mention how to disable them, but you can see here in Collabora code that [update checks are run only if the option is set to a value > 0](https://github.com/CollaboraOnline/online/blob/3b920a8264bf6de7e750784643ec95717a7e2c8a/wsd/COOLWSD.cpp#L3999)).

Lastly, I've removed the MKNOD capability from the Collabora container since it's not needed: [the official docs don't mention it in the required capabilities](https://sdk.collaboraonline.com/docs/installation/CODE_Docker_image.html#container-security-and-capability-management) and Collabora devs [have confirmed that the container does not use it](https://github.com/CollaboraOnline/online/issues/2800#issuecomment-2684147364). I'm running a manually-installed AIO and I can confirm that Collabora works fine without it.