### PR TITLE
aio-interface: Fix bypass_container_update when not detected as available

### DIFF
--- a/php/templates/containers.twig
+++ b/php/templates/containers.twig
@@ -353,6 +353,9 @@
                                         <input type="hidden" name="{{csrf.keys.name}}" value="{{csrf.name}}">
                                         <input type="hidden" name="{{csrf.keys.value}}" value="{{csrf.value}}">
                                         <input id="base_path" type="hidden" name="base_path" value="">
+                                        {% if bypass_container_update == true %}
+                                            <input type="hidden" name="bypass_container_update" value="true">
+                                        {% endif %}
                                         <input type="submit" value="Start containers" />
                                     </form>
                                 {% else %}
@@ -361,7 +364,7 @@
                                         <input type="hidden" name="{{csrf.keys.value}}" value="{{csrf.value}}">
                                         <input id="base_path" type="hidden" name="base_path" value="">
                                         {% if bypass_container_update == true %}
-                                            <input type="hidden" name="bypass_container_update" value="{{bypass_container_update}}">
+                                            <input type="hidden" name="bypass_container_update" value="true">
                                         {% endif %}
                                         <input class="button " type="submit" value="Start and update containers" onclick="return confirm('Start and update containers? You should consider creating a backup first.')" />
                                     </form>


### PR DESCRIPTION
isAnyUpdateAvailable is not necessarily synced with the PullImage logic from DockerActionManager. This ensures no images are pulled regardless of detection.

There's also a minor code improvement to avoid unnecessary interpolation.