### PR TITLE
mastercontainer: use remote-host caddy plugin only for login endpoints

### DIFF
--- a/Containers/mastercontainer/acme.Caddyfile
+++ b/Containers/mastercontainer/acme.Caddyfile
@@ -32,7 +32,10 @@ http://:80 {
 }
 
 https://:8443 {
-	@denied remote_host nextcloud-aio-nextcloud
+	@denied {
+		path /api/auth/login /api/auth/getlogin
+		remote_host nextcloud-aio-nextcloud
+	}
 	abort @denied
 
 	root * /var/www/docker-aio/php/public

--- a/Containers/mastercontainer/internal.Caddyfile
+++ b/Containers/mastercontainer/internal.Caddyfile
@@ -20,7 +20,10 @@
 }
 
 https://:8080 {
-	@denied remote_host nextcloud-aio-nextcloud
+	@denied {
+		path /api/auth/login /api/auth/getlogin
+		remote_host nextcloud-aio-nextcloud
+	}
 	abort @denied
 
 	root * /var/www/docker-aio/php/public


### PR DESCRIPTION
- Fix https://github.com/nextcloud/all-in-one/issues/7778
- Fix part of https://github.com/nextcloud/all-in-one/issues/7765