### PR TITLE
caddy-internal: adjust to different root path to separate from the acme caddy

### DIFF
--- a/Containers/mastercontainer/internal.Caddyfile
+++ b/Containers/mastercontainer/internal.Caddyfile
@@ -2,7 +2,7 @@
 	admin off
 
 	storage file_system {
-		root /mnt/docker-aio-config/caddy/
+		root /mnt/docker-aio-config/caddy-internal/
 	}
 
 	log {

--- a/Containers/mastercontainer/start.sh
+++ b/Containers/mastercontainer/start.sh
@@ -364,6 +364,7 @@ fi
 mkdir -p /mnt/docker-aio-config/data/
 mkdir -p /mnt/docker-aio-config/session/
 mkdir -p /mnt/docker-aio-config/caddy/
+mkdir -p /mnt/docker-aio-config/caddy-internal/
 
 # Adjust permissions for all instances
 chmod 770 -R /mnt/docker-aio-config
@@ -371,6 +372,7 @@ chmod 777 /mnt/docker-aio-config
 chown www-data:www-data -R /mnt/docker-aio-config/data/
 chown www-data:www-data -R /mnt/docker-aio-config/session/
 chown www-data:www-data -R /mnt/docker-aio-config/caddy/
+chown www-data:www-data -R /mnt/docker-aio-config/caddy-internal/
 
 print_green "Initial startup of Nextcloud All-in-One complete!
 You should be able to open the Nextcloud AIO Interface now on port 8080 of this server!


### PR DESCRIPTION
- Follow-up to https://github.com/nextcloud/all-in-one/pull/7006

Fix errors like
```
2026-04-02T07:52:08.392880844Z {"level":"error","ts":1775116328.3907871,"logger":"tls.renew","msg":"could not get certificate from issuer","identifier":"my-domain.com","issuer":"local","error":"authority.Sign; error creating certificate: error creating certificate: x509: provided PrivateKey doesn't match parent's PublicKey","errorVerbose":"x509: provided PrivateKey doesn't match parent's PublicKey\nerror creating certificate\ngo.step.sm/crypto/x509util.CreateCertificate\n\tgo.step.sm/crypto@v0.76.2/x509util/certificate.go:227\ngithub.com/smallstep/certificates/cas/softcas.createCertificate\n\tgithub.com/smallstep/certificates@v0.30.0-rc3/cas/softcas/softcas.go:284\ngithub.com/smallstep/certificates/cas/softcas.(*SoftCAS).CreateCertificate\n\tgithub.com/smallstep/certificates@v0.30.0-rc3/cas/softcas/softcas.go:93\ngithub.com/smallstep/certificates/authority.(*Authority).signX509\n\tgithub.com/smallstep/certificates@v0.30.0-rc3/authority/tls.go:302\ngithub.com/smallstep/certificates/authority.(*Authority).SignWithContext\n\tgithub.com/smallstep/certificates@v0.30.0-rc3/authority/tls.go:120\ngithub.com/caddyserver/caddy/v2/modules/caddytls.InternalIssuer.Issue\n\tgithub.com/caddyserver/caddy/v2@v2.11.2/modules/caddytls/internalissuer.go:133\ngithub.com/caddyserver/certmagic.(*Config).renewCert.func2\n\tgithub.com/caddyserver/certmagic@v0.25.2/config.go:952\ngithub.com/caddyserver/certmagic.doWithRetry\n\tgithub.com/caddyserver/certmagic@v0.25.2/async.go:104\ngithub.com/caddyserver/certmagic.(*Config).renewCert\n\tgithub.com/caddyserver/certmagic@v0.25.2/config.go:1028\ngithub.com/caddyserver/certmagic.(*Config).RenewCertAsync\n\tgithub.com/caddyserver/certmagic@v0.25.2/config.go:804\ngithub.com/caddyserver/certmagic.(*Config).renewDynamicCertificate.func2\n\tgithub.com/caddyserver/certmagic@v0.25.2/handshake.go:782\ngithub.com/caddyserver/certmagic.(*Config).renewDynamicCertificate\n\tgithub.com/caddyserver/certmagic@v0.25.2/handshake.go:810\ngithub.com/caddyserver/certmagic.(*Config).handshakeMaintenance.func1\n\tgithub.com/caddyserver/certmagic@v0.25.2/handshake.go:597\ngithub.com/caddyserver/certmagic.(*Config).handshakeMaintenance\n\tgithub.com/caddyserver/certmagic@v0.25.2/handshake.go:672\ngithub.com/caddyserver/certmagic.(*Config).optionalMaintenance\n\tgithub.com/caddyserver/certmagic@v0.25.2/handshake.go:453\ngithub.com/caddyserver/certmagic.(*Config).getCertDuringHandshake\n\tgithub.com/caddyserver/certmagic@v0.25.2/handshake.go:287\ngithub.com/caddyserver/certmagic.(*Config).GetCertificateWithContext\n\tgithub.com/caddyserver/certmagic@v0.25.2/handshake.go:93\ngithub.com/caddyserver/caddy/v2/modules/caddytls.(*ConnectionPolicy).buildStandardTLSConfig.func1\n\tgithub.com/caddyserver/caddy/v2@v2.11.2/modules/caddytls/connpolicy.go:316\ncrypto/tls.(*Config).getCertificate\n\tcrypto/tls/common.go:1320\ncrypto/tls.(*serverHandshakeStateTLS13).pickCertificate\n\tcrypto/tls/handshake_server_tls13.go:487\ncrypto/tls.(*serverHandshakeStateTLS13).handshake\n\tcrypto/tls/handshake_server_tls13.go:76\ncrypto/tls.(*Conn).serverHandshake\n\tcrypto/tls/handshake_server.go:55\ncrypto/tls.(*Conn).handshakeContext\n\tcrypto/tls/conn.go:1562\ncrypto/tls.(*Conn).HandshakeContext\n\tcrypto/tls/conn.go:1516\nnet/http.(*conn).serve\n\tnet/http/server.go:1931\nruntime.goexit\n\truntime/asm_amd64.s:1771\nauthority.Sign; error creating certificate\ngithub.com/smallstep/certificates/errs.Wrap\n\tgithub.com/smallstep/certificates@v0.30.0-rc3/errs/error.go:129\ngithub.com/smallstep/certificates/authority.(*Authority).signX509\n\tgithub.com/smallstep/certificates@v0.30.0-rc3/authority/tls.go:310\ngithub.com/smallstep/certificates/authority.(*Authority).SignWithContext\n\tgithub.com/smallstep/certificates@v0.30.0-rc3/authority/tls.go:120\ngithub.com/caddyserver/caddy/v2/modules/caddytls.InternalIssuer.Issue\n\tgithub.com/caddyserver/caddy/v2@v2.11.2/modules/caddytls/internalissuer.go:133\ngithub.com/caddyserver/certmagic.(*Config).renewCert.func2\n\tgithub.com/caddyserver/certmagic@v0.25.2/config.go:952\ngithub.com/caddyserver/certmagic.doWithRetry\n\tgithub.com/caddyserver/certmagic@v0.25.2/async.go:104\ngithub.com/caddyserver/certmagic.(*Config).renewCert\n\tgithub.com/caddyserver/certmagic@v0.25.2/config.go:1028\ngithub.com/caddyserver/certmagic.(*Config).RenewCertAsync\n\tgithub.com/caddyserver/certmagic@v0.25.2/config.go:804\ngithub.com/caddyserver/certmagic.(*Config).renewDynamicCertificate.func2\n\tgithub.com/caddyserver/certmagic@v0.25.2/handshake.go:782\ngithub.com/caddyserver/certmagic.(*Config).renewDynamicCertificate\n\tgithub.com/caddyserver/certmagic@v0.25.2/handshake.go:810\ngithub.com/caddyserver/certmagic.(*Config).handshakeMaintenance.func1\n\tgithub.com/caddyserver/certmagic@v0.25.2/handshake.go:597\ngithub.com/caddyserver/certmagic.(*Config).handshakeMaintenance\n\tgithub.com/caddyserver/certmagic@v0.25.2/handshake.go:672\ngithub.com/caddyserver/certmagic.(*Config).optionalMaintenance\n\tgithub.com/caddyserver/certmagic@v0.25.2/handshake.go:453\ngithub.com/caddyserver/certmagic.(*Config).getCertDuringHandshake\n\tgithub.com/caddyserver/certmagic@v0.25.2/handshake.go:287\ngithub.com/caddyserver/certmagic.(*Config).GetCertificateWithContext\n\tgithub.com/caddyserver/certmagic@v0.25.2/handshake.go:93\ngithub.com/caddyserver/caddy/v2/modules/caddytls.(*ConnectionPolicy).buildStandardTLSConfig.func1\n\tgithub.com/caddyserver/caddy/v2@v2.11.2/modules/caddytls/connpolicy.go:316\ncrypto/tls.(*Config).getCertificate\n\tcrypto/tls/common.go:1320\ncrypto/tls.(*serverHandshakeStateTLS13).pickCertificate\n\tcrypto/tls/handshake_server_tls13.go:487\ncrypto/tls.(*serverHandshakeStateTLS13).handshake\n\tcrypto/tls/handshake_server_tls13.go:76\ncrypto/tls.(*Conn).serverHandshake\n\tcrypto/tls/handshake_server.go:55\ncrypto/tls.(*Conn).handshakeContext\n\tcrypto/tls/conn.go:1562\ncrypto/tls.(*Conn).HandshakeContext\n\tcrypto/tls/conn.go:1516\nnet/http.(*conn).serve\n\tnet/http/server.go:1931\nruntime.goexit\n\truntime/asm_amd64.s:1771"}
2026-04-02T07:52:08.393040223Z {"level":"error","ts":1775116328.391833,"logger":"tls.renew","msg":"will retry","error":"[my-domain.com] Renew: authority.Sign; error creating certificate: error creating certificate: x509: provided PrivateKey doesn't match parent's PublicKey","attempt":2,"retrying_in":120,"elapsed":60.013179905,"max_duration":2592000}
2026-04-02T07:52:38.379726425Z {"level":"error","ts":1775116358.378143,"logger":"tls.on_demand","msg":"renewing and reloading certificate","remote_ip":"fdf2:24b8:2e1c::1","remote_port":"59124","server_name":"my-domain.com","subjects":["my-domain.com"],"expiration":1774784733,"remaining":-331535.373789524,"revoked":false,"server_name":"my-domain.com","error":"context canceled"}
2026-04-02T07:52:38.379779258Z {"level":"error","ts":1775116358.3782158,"logger":"tls.on_demand","msg":"renewing certificate on-demand failed","subjects":["my-domain.com"],"not_after":1774784733,"error":"context canceled"}
```