### PR TITLE
aio-interface: regenerate session id on login to avoid session fixation attacks

### DIFF
--- a/php/src/Auth/AuthManager.php
+++ b/php/src/Auth/AuthManager.php
@@ -26,6 +26,7 @@ readonly class AuthManager {
     public function SetAuthState(bool $isLoggedIn) : void {
 
         if (!$this->IsAuthenticated() && $isLoggedIn === true) {
+            session_regenerate_id(true);
             $date = new DateTime();
             $dateTime = $date->getTimestamp();
             $_SESSION['date_time'] = $dateTime;


### PR DESCRIPTION
A simple change with relevant impact.