### PR TITLE
aio-interface: Use timeing-safe password comparison

### DIFF
--- a/php/src/Data/ConfigurationManager.php
+++ b/php/src/Data/ConfigurationManager.php
@@ -657,7 +657,7 @@ class ConfigurationManager
             throw new InvalidSettingConfigurationException("Please enter your current password.");
         }
 
-        if ($currentPassword !== $this->password) {
+        if (!hash_equals($this->password, $currentPassword)) {
             throw new InvalidSettingConfigurationException("The entered current password is not correct.");
         }
 


### PR DESCRIPTION
`AuthManager` already used `hash_equal`, but `ConfigurationManager` didn't yet. We should use it to mitigate timing attacks.