### PR TITLE
aio-interface: avoid `Resend` popups on Firefox on start/stop containers

### DIFF
--- a/php/public/automatic_reload.js
+++ b/php/public/automatic_reload.js
@@ -9,7 +9,7 @@ window.addEventListener("load", function(event) {
 
         // set timeout for reload
         setTimeout(function(){
-        window.location.reload(1);
+        window.location.reload(true);
         }, 5000);
     } else {
         window.addEventListener("beforeunload", function() {

--- a/php/public/forms.js
+++ b/php/public/forms.js
@@ -36,11 +36,11 @@ function showPassword(id) {
       showError("Server error. Please check the mastercontainer logs for details. This page will reload after 10s automatically. Then you can check the mastercontainer logs.");
       // Reload after 10s since it is expected that the updated view is shown (e.g. after starting containers)
       setTimeout(function(){
-        window.location.reload(1);
+        window.location.reload(true);
       }, 10000);
     } else {
       // If the responose is not one of the above, we should reload to show the latest content
-      window.location.reload(1);
+      window.location.reload(true);
     }
   }
 
@@ -84,7 +84,7 @@ function showPassword(id) {
             document.getElementById('overlay-log')?.classList.add('visible');
             // Reload the page after the response was fully loaded into the iframe.
             document.querySelector('iframe[name="overlay-log"]').addEventListener('load', () => {
-                location.reload();
+                location.reload(true);
             });
         };
     }

--- a/php/templates/containers.twig
+++ b/php/templates/containers.twig
@@ -635,7 +635,7 @@
             {% endif %}
 
         {% if isApacheStarting == true or is_backup_container_running == true or isWatchtowerRunning == true or is_daily_backup_running == true %}
-            <script type="text/javascript" src="automatic_reload.js?v1"></script>
+            <script type="text/javascript" src="automatic_reload.js?v2"></script>
         {% else %}
             <script type="text/javascript" src="before-unload.js"></script>
         {% endif %}

--- a/php/templates/layout.twig
+++ b/php/templates/layout.twig
@@ -3,7 +3,7 @@
         <title>AIO</title>
         <link rel="stylesheet" href="style.css?v9" media="all" />
         <link rel="icon" href="img/favicon.png">
-        <script type="text/javascript" src="forms.js?v1"></script>
+        <script type="text/javascript" src="forms.js?v2"></script>
         <script type="text/javascript" src="toggle-dark-mode.js?v1"></script>
     </head>
 


### PR DESCRIPTION
Use `location.reload(true)` instead of `reload` or `reload(1)` to ensure we use a GET request when reloading the page after streaming the `start` or `stop` request completes.

See also:
https://stackoverflow.com/a/41122753
https://developer.mozilla.org/en-US/docs/Web/API/Location/reload#forceget

- Fixes #7850
- Close https://github.com/nextcloud/all-in-one/issues/7833
