### PR TITLE
Add dev convenience script for building containers

### DIFF
--- a/scripts/build-containers.sh
+++ b/scripts/build-containers.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+VARIANT="develop"
+CONTAINERS=()
+
+# Parse flags first
+while [[ $# -gt 0 && $1 == --* ]]; do
+  case $1 in
+    --variant)
+      VARIANT="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# Remaining arguments are containers
+CONTAINERS=("$@")
+
+if [ ${#CONTAINERS[@]} -eq 0 ]; then
+    echo "Usage: $0 [--variant develop|beta] <container1> [container2] [container3] ..."
+    echo "Example: $0 --variant beta apache mastercontainer"
+    exit 1
+fi
+
+# Change to project root
+cd "$(dirname "$0")/.." || exit 1
+
+for container in "${CONTAINERS[@]}"; do
+  if [[ $container == "mastercontainer" ]]; then
+    TAG="all-in-one"
+  else
+    TAG="aio-$container"
+  fi
+
+  if [[ $container == "mastercontainer" || $container == "nextcloud" ]]; then
+      CONTEXT="."
+  else
+      CONTEXT="Containers/$container"
+  fi
+
+  docker buildx build --file Containers/$container/Dockerfile --tag ghcr.io/nextcloud-releases/"$TAG":"$VARIANT" --load $CONTEXT
+done
+


### PR DESCRIPTION
A small script to make building the containers for local dev testing a little easier:

```
Usage: ./scripts/build-containers.sh [--variant develop|beta] <container1> [container2] [container3] ...
Example: ./scripts/build-containers.sh --variant beta apache mastercontainer
```

Feel free to reject this if there's a better way.