### PR TITLE
Update Prometheus Nextcloud Exporter to 0.9.1

### DIFF
--- a/community-containers/nextcloud-exporter/nextcloud-exporter.json
+++ b/community-containers/nextcloud-exporter/nextcloud-exporter.json
@@ -5,7 +5,7 @@
             "display_name": "Prometheus Nextcloud Exporter",
             "documentation": "https://github.com/nextcloud/all-in-one/tree/main/community-containers/nextcloud-exporter",
             "image": "ghcr.io/xperimental/nextcloud-exporter",
-            "image_tag": "0.9.0",
+            "image_tag": "0.9.1",
             "internal_port": "9205",
             "restart": "unless-stopped",
             "ports": [


### PR DESCRIPTION
Updates  Prometheus Nextcloud Exporter to version 0.9.1

Just a small update see: https://github.com/xperimental/nextcloud-exporter/releases/tag/v0.9.1

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->
