### PR TITLE
apache: Add an explanation why we disable the HTTP challenge in that Caddy instance

### DIFF
--- a/Containers/apache/Caddyfile
+++ b/Containers/apache/Caddyfile
@@ -75,6 +75,7 @@ http://{$APACHE_HOST}.nextcloud-aio:23973, # For Collabora callback and WOPI req
     tls {
         issuer acme {
             profile shortlived
+            # Disable HTTP challenge because that would require port 80, which we don't get (it's exposed to the mastercontainer).
             disable_http_challenge
         }
     }

--- a/Containers/apache/Caddyfile
+++ b/Containers/apache/Caddyfile
@@ -76,6 +76,7 @@ http://{$APACHE_HOST}.nextcloud-aio:23973, # For Collabora callback and WOPI req
         issuer acme {
             profile shortlived
             # Disable HTTP challenge because that would require port 80, which we don't get (it's exposed to the mastercontainer).
+            # This container by default only exposes port 443 if not configured otherwise via APACHE_PORT.
             disable_http_challenge
         }
     }


### PR DESCRIPTION
It confused people before, maybe this helps a little bit.