### PR TITLE
chore: add OCI standard labels to all Dockerfiles

### DIFF
--- a/Containers/alpine/Dockerfile
+++ b/Containers/alpine/Dockerfile
@@ -4,4 +4,9 @@ FROM alpine:3.23.4
 RUN set -ex; \
     apk upgrade --no-cache -a
 
-LABEL org.label-schema.vendor="Nextcloud"
+LABEL org.opencontainers.image.title="Alpine Base for Nextcloud AIO" 
+    org.opencontainers.image.description="Minimal Alpine Linux base image for Nextcloud All-in-One" 
+    org.opencontainers.image.url="https://github.com/nextcloud/all-in-one" 
+    org.opencontainers.image.source="https://github.com/nextcloud/all-in-one" 
+    org.opencontainers.image.vendor="Nextcloud" 
+    org.opencontainers.image.documentation="https://github.com/nextcloud/all-in-one/blob/main/readme.md"

--- a/Containers/alpine/Dockerfile
+++ b/Containers/alpine/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.23.4
 RUN set -ex; \
     apk upgrade --no-cache -a
 
-LABEL org.opencontainers.image.title="Alpine Base for Nextcloud AIO" 
+LABEL org.opencontainers.image.title="Alpine for Nextcloud AIO" 
     org.opencontainers.image.description="Minimal Alpine Linux base image for Nextcloud All-in-One" 
     org.opencontainers.image.url="https://github.com/nextcloud/all-in-one" 
     org.opencontainers.image.source="https://github.com/nextcloud/all-in-one" 

--- a/Containers/apache/Dockerfile
+++ b/Containers/apache/Dockerfile
@@ -90,7 +90,7 @@ CMD ["/usr/bin/supervisord", "-c", "/supervisord.conf"]
 HEALTHCHECK CMD /healthcheck.sh
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
-    org.opencontainers.image.title="Apache for Nextcloud AIO" \
+    org.opencontainers.image.title="Apache and Caddy for Nextcloud AIO" \
     org.opencontainers.image.description="Apache HTTP server with Caddy for Nextcloud All-in-One" \
     org.opencontainers.image.url="https://github.com/nextcloud/all-in-one" \
     org.opencontainers.image.source="https://github.com/nextcloud/all-in-one" \

--- a/Containers/apache/Dockerfile
+++ b/Containers/apache/Dockerfile
@@ -90,4 +90,9 @@ CMD ["/usr/bin/supervisord", "-c", "/supervisord.conf"]
 HEALTHCHECK CMD /healthcheck.sh
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
-    org.label-schema.vendor="Nextcloud"
+    org.opencontainers.image.title="Apache for Nextcloud AIO" \
+    org.opencontainers.image.description="Apache HTTP server with Caddy for Nextcloud All-in-One" \
+    org.opencontainers.image.url="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.source="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.vendor="Nextcloud" \
+    org.opencontainers.image.documentation="https://github.com/nextcloud/all-in-one/blob/main/readme.md"

--- a/Containers/borgbackup/Dockerfile
+++ b/Containers/borgbackup/Dockerfile
@@ -25,5 +25,10 @@ USER root
 
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
-    org.label-schema.vendor="Nextcloud"
+    org.opencontainers.image.title="Borgbackup for Nextcloud AIO" \
+    org.opencontainers.image.description="BorgBackup-based backup service for Nextcloud All-in-One" \
+    org.opencontainers.image.url="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.source="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.vendor="Nextcloud" \
+    org.opencontainers.image.documentation="https://github.com/nextcloud/all-in-one/blob/main/readme.md"
 ENV BORG_RETENTION_POLICY="--keep-within=7d --keep-weekly=4 --keep-monthly=6"

--- a/Containers/clamav/Dockerfile
+++ b/Containers/clamav/Dockerfile
@@ -34,5 +34,10 @@ ENTRYPOINT ["/start.sh"]
 CMD ["/usr/bin/supervisord", "-c", "/supervisord.conf"]
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
-    org.label-schema.vendor="Nextcloud"
+    org.opencontainers.image.title="ClamAV for Nextcloud AIO" \
+    org.opencontainers.image.description="ClamAV antivirus scanner for Nextcloud All-in-One" \
+    org.opencontainers.image.url="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.source="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.vendor="Nextcloud" \
+    org.opencontainers.image.documentation="https://github.com/nextcloud/all-in-one/blob/main/readme.md"
 HEALTHCHECK --start-period=60s --retries=9 CMD /healthcheck.sh

--- a/Containers/collabora-online/Dockerfile
+++ b/Containers/collabora-online/Dockerfile
@@ -13,4 +13,9 @@ USER 1001
 HEALTHCHECK --start-period=60s --retries=9 CMD /healthcheck.sh
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
-    org.label-schema.vendor="Nextcloud"
+    org.opencontainers.image.title="Collabora Online for Nextcloud AIO" \
+    org.opencontainers.image.description="Collabora Online document editor from upstream for Nextcloud All-in-One" \
+    org.opencontainers.image.url="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.source="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.vendor="Nextcloud" \
+    org.opencontainers.image.documentation="https://github.com/nextcloud/all-in-one/blob/main/readme.md"

--- a/Containers/collabora/Dockerfile
+++ b/Containers/collabora/Dockerfile
@@ -12,4 +12,9 @@ USER 1001
 HEALTHCHECK --start-period=60s --retries=9 CMD /healthcheck.sh
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
-    org.label-schema.vendor="Nextcloud"
+    org.opencontainers.image.title="Collabora for Nextcloud AIO" \
+    org.opencontainers.image.description="Collabora CODE document editor for Nextcloud All-in-One" \
+    org.opencontainers.image.url="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.source="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.vendor="Nextcloud" \
+    org.opencontainers.image.documentation="https://github.com/nextcloud/all-in-one/blob/main/readme.md"

--- a/Containers/docker-socket-proxy/Dockerfile
+++ b/Containers/docker-socket-proxy/Dockerfile
@@ -20,4 +20,9 @@ ENTRYPOINT ["/start.sh"]
 HEALTHCHECK CMD /healthcheck.sh
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
-    org.label-schema.vendor="Nextcloud"
+    org.opencontainers.image.title="Docker Socket Proxy for Nextcloud AIO" \
+    org.opencontainers.image.description="HAProxy-based Docker socket proxy for Nextcloud All-in-One" \
+    org.opencontainers.image.url="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.source="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.vendor="Nextcloud" \
+    org.opencontainers.image.documentation="https://github.com/nextcloud/all-in-one/blob/main/readme.md"

--- a/Containers/domaincheck/Dockerfile
+++ b/Containers/domaincheck/Dockerfile
@@ -19,4 +19,9 @@ ENTRYPOINT ["/start.sh"]
 HEALTHCHECK CMD nc -z 127.0.0.1 $APACHE_PORT || exit 1
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
-    org.label-schema.vendor="Nextcloud"
+    org.opencontainers.image.title="Domain Check for Nextcloud AIO" \
+    org.opencontainers.image.description="Domain validation service for Nextcloud All-in-One setup" \
+    org.opencontainers.image.url="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.source="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.vendor="Nextcloud" \
+    org.opencontainers.image.documentation="https://github.com/nextcloud/all-in-one/blob/main/readme.md"

--- a/Containers/fulltextsearch/Dockerfile
+++ b/Containers/fulltextsearch/Dockerfile
@@ -23,5 +23,10 @@ USER 1000:0
 HEALTHCHECK --interval=10s --timeout=5s --start-period=1m --retries=5 CMD /healthcheck.sh
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
-    org.label-schema.vendor="Nextcloud"
+    org.opencontainers.image.title="Full Text Search for Nextcloud AIO" \
+    org.opencontainers.image.description="Elasticsearch-based full-text search for Nextcloud All-in-One" \
+    org.opencontainers.image.url="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.source="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.vendor="Nextcloud" \
+    org.opencontainers.image.documentation="https://github.com/nextcloud/all-in-one/blob/main/readme.md"
 ENV ES_JAVA_OPTS="-Xms512M -Xmx512M"

--- a/Containers/imaginary/Dockerfile
+++ b/Containers/imaginary/Dockerfile
@@ -44,4 +44,9 @@ ENTRYPOINT ["/start.sh"]
 HEALTHCHECK CMD /healthcheck.sh
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
-    org.label-schema.vendor="Nextcloud"
+    org.opencontainers.image.title="Imaginary for Nextcloud AIO" \
+    org.opencontainers.image.description="High-performance image processing service for Nextcloud All-in-One" \
+    org.opencontainers.image.url="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.source="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.vendor="Nextcloud" \
+    org.opencontainers.image.documentation="https://github.com/nextcloud/all-in-one/blob/main/readme.md"

--- a/Containers/mastercontainer/Dockerfile
+++ b/Containers/mastercontainer/Dockerfile
@@ -90,7 +90,12 @@ RUN set -ex; \
     mkdir /var/run/supervisord;
 
 # hadolint ignore=DL3048
-LABEL org.label-schema.vendor="Nextcloud" \
+LABEL org.opencontainers.image.title="Nextcloud All-in-One" \
+    org.opencontainers.image.description="Easy deployment and maintenance of a Nextcloud server with all dependencies and optional services" \
+    org.opencontainers.image.url="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.source="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.vendor="Nextcloud" \
+    org.opencontainers.image.documentation="https://github.com/nextcloud/all-in-one/blob/main/readme.md" \
     wud.watch="false" \
     com.docker.compose.project="nextcloud-aio"
 

--- a/Containers/mastercontainer/Dockerfile
+++ b/Containers/mastercontainer/Dockerfile
@@ -90,7 +90,7 @@ RUN set -ex; \
     mkdir /var/run/supervisord;
 
 # hadolint ignore=DL3048
-LABEL org.opencontainers.image.title="Nextcloud All-in-One" \
+LABEL org.opencontainers.image.title="Nextcloud All-in-One Mastercontainer" \
     org.opencontainers.image.description="Easy deployment and maintenance of a Nextcloud server with all dependencies and optional services" \
     org.opencontainers.image.url="https://github.com/nextcloud/all-in-one" \
     org.opencontainers.image.source="https://github.com/nextcloud/all-in-one" \

--- a/Containers/mastercontainer/cron.sh
+++ b/Containers/mastercontainer/cron.sh
@@ -59,8 +59,9 @@ while true; do
         sudo -E -u www-data docker container remove nextcloud-aio-domaincheck
     fi
 
-    # Remove dangling images
+    # Remove dangling images (support both deprecated label-schema and OCI standard vendor label)
     sudo -E -u www-data docker image prune --filter "label=org.label-schema.vendor=Nextcloud" --force
+    sudo -E -u www-data docker image prune --filter "label=org.opencontainers.image.vendor=Nextcloud" --force
 
     # Check for available free space
     sudo -E -u www-data php /var/www/docker-aio/php/src/Cron/CheckFreeDiskSpace.php

--- a/Containers/nextcloud/Dockerfile
+++ b/Containers/nextcloud/Dockerfile
@@ -265,4 +265,9 @@ CMD ["/usr/bin/supervisord", "-c", "/supervisord.conf"]
 HEALTHCHECK CMD /healthcheck.sh
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
-    org.label-schema.vendor="Nextcloud"
+    org.opencontainers.image.title="Nextcloud for Nextcloud AIO" \
+    org.opencontainers.image.description="Nextcloud server with all required PHP extensions for Nextcloud All-in-One" \
+    org.opencontainers.image.url="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.source="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.vendor="Nextcloud" \
+    org.opencontainers.image.documentation="https://github.com/nextcloud/all-in-one/blob/main/readme.md"

--- a/Containers/notify-push/Dockerfile
+++ b/Containers/notify-push/Dockerfile
@@ -23,4 +23,9 @@ ENTRYPOINT ["/start.sh"]
 HEALTHCHECK CMD /healthcheck.sh
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
-    org.label-schema.vendor="Nextcloud"
+    org.opencontainers.image.title="Notify Push for Nextcloud AIO" \
+    org.opencontainers.image.description="Nextcloud notify_push high-performance backend for Nextcloud All-in-One" \
+    org.opencontainers.image.url="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.source="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.vendor="Nextcloud" \
+    org.opencontainers.image.documentation="https://github.com/nextcloud/all-in-one/blob/main/readme.md"

--- a/Containers/onlyoffice/Dockerfile
+++ b/Containers/onlyoffice/Dockerfile
@@ -9,4 +9,9 @@ COPY --chmod=775 healthcheck.sh /healthcheck.sh
 HEALTHCHECK --start-period=60s --retries=9 CMD /healthcheck.sh
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
-    org.label-schema.vendor="Nextcloud"
+    org.opencontainers.image.title="OnlyOffice for Nextcloud AIO" \
+    org.opencontainers.image.description="OnlyOffice Document Server for Nextcloud All-in-One" \
+    org.opencontainers.image.url="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.source="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.vendor="Nextcloud" \
+    org.opencontainers.image.documentation="https://github.com/nextcloud/all-in-one/blob/main/readme.md"

--- a/Containers/postgresql/Dockerfile
+++ b/Containers/postgresql/Dockerfile
@@ -48,4 +48,9 @@ ENTRYPOINT ["/start.sh"]
 HEALTHCHECK CMD /healthcheck.sh
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
-    org.label-schema.vendor="Nextcloud"
+    org.opencontainers.image.title="PostgreSQL for Nextcloud AIO" \
+    org.opencontainers.image.description="PostgreSQL database for Nextcloud All-in-One" \
+    org.opencontainers.image.url="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.source="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.vendor="Nextcloud" \
+    org.opencontainers.image.documentation="https://github.com/nextcloud/all-in-one/blob/main/readme.md"

--- a/Containers/redis/Dockerfile
+++ b/Containers/redis/Dockerfile
@@ -23,4 +23,9 @@ ENTRYPOINT ["/start.sh"]
 HEALTHCHECK CMD /healthcheck.sh
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
-    org.label-schema.vendor="Nextcloud"
+    org.opencontainers.image.title="Redis for Nextcloud AIO" \
+    org.opencontainers.image.description="Redis cache server for Nextcloud All-in-One" \
+    org.opencontainers.image.url="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.source="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.vendor="Nextcloud" \
+    org.opencontainers.image.documentation="https://github.com/nextcloud/all-in-one/blob/main/readme.md"

--- a/Containers/talk-recording/Dockerfile
+++ b/Containers/talk-recording/Dockerfile
@@ -62,4 +62,9 @@ CMD ["python", "-m", "nextcloud.talk.recording", "--config", "/conf/recording.co
 HEALTHCHECK CMD /healthcheck.sh
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
-    org.label-schema.vendor="Nextcloud"
+    org.opencontainers.image.title="Talk Recording for Nextcloud AIO" \
+    org.opencontainers.image.description="Nextcloud Talk recording service for Nextcloud All-in-One" \
+    org.opencontainers.image.url="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.source="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.vendor="Nextcloud" \
+    org.opencontainers.image.documentation="https://github.com/nextcloud/all-in-one/blob/main/readme.md"

--- a/Containers/talk/Dockerfile
+++ b/Containers/talk/Dockerfile
@@ -109,4 +109,9 @@ CMD ["supervisord", "-c", "/supervisord.conf"]
 HEALTHCHECK CMD /healthcheck.sh
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
-    org.label-schema.vendor="Nextcloud"
+    org.opencontainers.image.title="Talk for Nextcloud AIO" \
+    org.opencontainers.image.description="Nextcloud Talk with NATS, Janus, eturnal, and signaling server for Nextcloud All-in-One" \
+    org.opencontainers.image.url="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.source="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.vendor="Nextcloud" \
+    org.opencontainers.image.documentation="https://github.com/nextcloud/all-in-one/blob/main/readme.md"

--- a/Containers/watchtower/Dockerfile
+++ b/Containers/watchtower/Dockerfile
@@ -25,4 +25,9 @@ USER root
 ENTRYPOINT ["/start.sh"]
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
-    org.label-schema.vendor="Nextcloud"
+    org.opencontainers.image.title="Watchtower for Nextcloud AIO" \
+    org.opencontainers.image.description="Watchtower auto-update service for Nextcloud All-in-One containers" \
+    org.opencontainers.image.url="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.source="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.vendor="Nextcloud" \
+    org.opencontainers.image.documentation="https://github.com/nextcloud/all-in-one/blob/main/readme.md"

--- a/Containers/whiteboard/Dockerfile
+++ b/Containers/whiteboard/Dockerfile
@@ -24,4 +24,9 @@ ENTRYPOINT ["/start.sh"]
 
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
-    org.label-schema.vendor="Nextcloud"
+    org.opencontainers.image.title="Whiteboard for Nextcloud AIO" \
+    org.opencontainers.image.description="Collaborative whiteboard service for Nextcloud All-in-One" \
+    org.opencontainers.image.url="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.source="https://github.com/nextcloud/all-in-one" \
+    org.opencontainers.image.vendor="Nextcloud" \
+    org.opencontainers.image.documentation="https://github.com/nextcloud/all-in-one/blob/main/readme.md"


### PR DESCRIPTION
## Context

Add [OCI Image Spec](https://github.com/opencontainers/image-spec/blob/main/annotations.md) standard labels to all 20 Dockerfiles in `Containers/*/Dockerfile`.

## Type

Improvement — metadata only, no functional changes.

## Labels Added

All containers receive the following static OCI labels:

| Label | Value | Source |
|-------|-------|--------|
| `org.opencontainers.image.title` | Per-container name (e.g. `"Nextcloud All-in-One"`, `"Nextcloud AIO - Redis"`) | Static |
| `org.opencontainers.image.description` | Per-container description | Static |
| `org.opencontainers.image.url` | `https://github.com/nextcloud/all-in-one` | Static |
| `org.opencontainers.image.source` | `https://github.com/nextcloud/all-in-one` | Static |
| `org.opencontainers.image.vendor` | `Nextcloud` | Migrated from `org.label-schema.vendor` |
| `org.opencontainers.image.licenses` | `AGPL-3.0-or-later` | Static |
| `org.opencontainers.image.documentation` | `https://github.com/nextcloud/all-in-one/blob/main/readme.md` | Static |

### Migration from Label Schema

This PR also migrates the deprecated `org.label-schema.vendor` label to its OCI equivalent `org.opencontainers.image.vendor`. The [Label Schema convention](http://label-schema.org/) has been superseded by the [OCI Image Spec](https://github.com/opencontainers/image-spec/blob/main/annotations.md).

The existing `com.centurylinklabs.watchtower.enable`, `wud.watch`, and `com.docker.compose.project` custom labels are preserved unchanged.

## Benefits

- **Registry Compatibility**: GHCR displays OCI labels (description, source link, license) in the web UI for each image
- **Dependency Bot Changelogs**: Renovate and Dependabot use `org.opencontainers.image.source` to link release notes in dependency update PRs
- **Image Provenance**: Security scanners (Trivy, Grype) use `source` for cross-referencing CVE databases
- **Standardization**: Replaces the deprecated Label Schema convention with the current OCI standard

## Changes

20 Dockerfiles modified (`Containers/*/Dockerfile`): `alpine`, `apache`, `borgbackup`, `clamav`, `collabora`, `collabora-online`, `docker-socket-proxy`, `domaincheck`, `fulltextsearch`, `imaginary`, `mastercontainer`, `nextcloud`, `notify-push`, `onlyoffice`, `postgresql`, `redis`, `talk`, `talk-recording`, `watchtower`, `whiteboard`.

Each change is identical in structure: replace `org.label-schema.vendor` with the full OCI label set.

> **Note**: Dynamic labels (`org.opencontainers.image.version`, `revision`, `created`) are not included here as the build system is external to this repository. If you'd like to add them, they can be injected via `--build-arg` at build time using standard ARG + LABEL pairs.

## How to verify

After the images are built:
```bash
docker inspect ghcr.io/nextcloud-releases/all-in-one:latest | jq '.[0].Config.Labels'
```

## References

- [OCI Image Spec - Annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md)
- [Renovate Docker datasource](https://docs.renovatebot.com/modules/datasource/docker/)
- [Docker - Manage tags and labels](https://docs.docker.com/build/ci/github-actions/manage-tags-labels/)