### PR TITLE
nextcloud-exporter: update readme to reflect what it monitors

### DIFF
--- a/community-containers/nextcloud-exporter/readme.md
+++ b/community-containers/nextcloud-exporter/readme.md
@@ -30,7 +30,6 @@ See the [Community Containers documentation](https://github.com/nextcloud/all-in
 - User activity (active users hourly, daily)
 - File counts and storage usage
 - System health and database size
-- App statistics and update availability
 - Nextcloud performance metrics
 
 ### Prometheus Configuration


### PR DESCRIPTION
as discussed in https://github.com/nextcloud/all-in-one/discussions/2513#discussioncomment-16533918 the current deployment does not monitor app statistics and update availability

So let's update the readme to reflect that