### PR TITLE
nextcloud: add `server.config.php` that adds the serverid by using the hostname as key

### DIFF
--- a/Containers/nextcloud/config/server.config.php
+++ b/Containers/nextcloud/config/server.config.php
@@ -1,0 +1,4 @@
+<?php
+$CONFIG = array (
+  'serverid' => crc32(gethostname()) % 512,
+);


### PR DESCRIPTION
- For https://github.com/nextcloud/all-in-one/issues/7622