### PR TITLE
notify-push & imaginary: terminate containers on SIGTERM

### DIFF
--- a/Containers/imaginary/start.sh
+++ b/Containers/imaginary/start.sh
@@ -8,4 +8,4 @@ if [ -n "$IMAGINARY_SECRET" ]; then
     IMAGINARY_ARGS+=(-key "$IMAGINARY_SECRET")
 fi
 
-imaginary "${IMAGINARY_ARGS[@]}" "$@"
+exec imaginary "${IMAGINARY_ARGS[@]}" "$@"

--- a/Containers/notify-push/start.sh
+++ b/Containers/notify-push/start.sh
@@ -42,5 +42,3 @@ echo "notify-push was started"
 exec /var/www/html/custom_apps/notify_push/bin/"$CPU_ARCH"/notify_push \
     --port 7867 \
     /var/www/html/config/config.php
-
-exec "$@"

--- a/Containers/notify-push/start.sh
+++ b/Containers/notify-push/start.sh
@@ -39,7 +39,7 @@ fi
 echo "notify-push was started"
 
 # Run it
-/var/www/html/custom_apps/notify_push/bin/"$CPU_ARCH"/notify_push \
+exec /var/www/html/custom_apps/notify_push/bin/"$CPU_ARCH"/notify_push \
     --port 7867 \
     /var/www/html/config/config.php
 


### PR DESCRIPTION
Some containers don't forward SIGTERM signals to their main process. On podman kube down I receive
```
WARN[0010] StopSignal SIGWINCH failed to stop container nextcloud-enterprise-apache-pod-nextcloud-enterprise-apache in 10 seconds, resorting to SIGKILL 
WARN[0020] StopSignal SIGTERM failed to stop container nextcloud-enterprise-imaginary-pod-nextcloud-enterprise-imaginary in 10 seconds, resorting to SIGKILL 
WARN[0033] StopSignal SIGTERM failed to stop container nextcloud-enterprise-notify-push-pod-nextcloud-enterprise-notify-push in 10 seconds, resorting to SIGKILL
```

with these patches I get
```
WARN[0010] StopSignal SIGWINCH failed to stop container nextcloud-enterprise-apache-pod-nextcloud-enterprise-apache in 10 seconds, resorting to SIGKILL
```

That's right, I didn't manage to fix the apache container (even though I tried `STOPSIGNAL SIGTERM` in the dockerfile). notify-push and imaginary are fixed though.