### PR TITLE
Drop as much capabilities as possibile for the Collabora container

### DIFF
--- a/php/containers.json
+++ b/php/containers.json
@@ -406,7 +406,7 @@
         "CHOWN"
       ],
       "cap_drop": [
-        "NET_RAW"
+        "ALL"
       ]
     },
     {

--- a/php/src/Container/Container.php
+++ b/php/src/Container/Container.php
@@ -27,6 +27,8 @@ readonly class Container {
         public bool                          $enableNvidiaGpu,
         /** @var string[] */
         public array                         $capAdd,
+        /** @var string[] */
+        public array                         $capDrop,
         public int                           $shmSize,
         public bool                          $apparmorUnconfined,
         /** @var string[] */

--- a/php/src/ContainerDefinitionFetcher.php
+++ b/php/src/ContainerDefinitionFetcher.php
@@ -298,6 +298,11 @@ readonly class ContainerDefinitionFetcher {
                 $capAdd = $entry['cap_add'];
             }
 
+            $capDrop = [];
+            if (isset($entry['cap_drop'])) {
+                $capDrop = $entry['cap_drop'];
+            }
+
             $shmSize = -1;
             if (isset($entry['shm_size'])) {
                 $shmSize = $entry['shm_size'];
@@ -360,6 +365,7 @@ readonly class ContainerDefinitionFetcher {
                 $devices,
                 $enableNvidiaGpu,
                 $capAdd,
+                $capDrop,
                 $shmSize,
                 $apparmorUnconfined,
                 $backupVolumes,

--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -440,9 +440,11 @@ readonly class DockerActionManager {
         // Special things for the collabora container which should not be exposed in the containers.json
         } elseif ($container->identifier === 'nextcloud-aio-collabora') {
             if (!$this->configurationManager->collaboraSeccompDisabled) {
-                // Load reference seccomp profile for collabora
+                // Load reference seccomp profile for collabora...
                 $seccompProfile = (string)file_get_contents(DataConst::GetCollaboraSeccompProfilePath());
                 $requestBody['HostConfig']['SecurityOpt'] = ["label:disable", "seccomp=$seccompProfile"];
+                // ...which allows the collabora container to run without any capabilities
+                $requestBody['HostConfig']['CapAdd'] = [];
             }
 
             // Additional Collabora options

--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -378,9 +378,9 @@ readonly class DockerActionManager {
             $requestBody['HostConfig']['CapAdd'] = $capAdds;
         }
 
-        // Disable arp spoofing
-        if (!in_array('NET_RAW', $capAdds, true)) {
-            $requestBody['HostConfig']['CapDrop'] = ['NET_RAW'];
+        $capDrops = $container->capDrop;
+        if (count($capDrops) > 0) {
+            $requestBody['HostConfig']['CapDrop'] = $capDrops;
         }
 
         // Disable SELinux for AIO containers so that it does not break them

--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -381,6 +381,9 @@ readonly class DockerActionManager {
         $capDrops = $container->capDrop;
         if (count($capDrops) > 0) {
             $requestBody['HostConfig']['CapDrop'] = $capDrops;
+        } else if (!in_array('NET_RAW', $capAdds, true)) {
+            // Prevent ARP spoofing by default
+            $requestBody['HostConfig']['CapDrop'] = ['NET_RAW'];
         }
 
         // Disable SELinux for AIO containers so that it does not break them


### PR DESCRIPTION
As per [their official docs](https://sdk.collaboraonline.com/docs/installation/CODE_Docker_image.html#container-security-and-capability-management), the Collabora container doesn't need any other capabilities in addition to those explicitly added to run correctly. Furthermore, when the seccomp profile is used, it doesn't need any capabilities at all.

This PR implements the required changes to run the Collabora container with `cap-drop=ALL`, and also removes all added capabilities when the container is run with the seccomp profile. I can confirm that the latter scenario works fine, because I've tested it on a manual-install customized to use the seccomp profile.