### PR TITLE
feat(notify-push): add NOTIFY_PUSH_NEXTCLOUD_URL to bypass upstream reverse proxy

### DIFF
--- a/Containers/notify-push/start.sh
+++ b/Containers/notify-push/start.sh
@@ -44,7 +44,19 @@ fi
 
 echo "notify-push was started"
 
+# Build optional --nextcloud-url flag.
+# Set NOTIFY_PUSH_NEXTCLOUD_URL to an internal URL (e.g. https://nextcloud-aio-apache)
+# when an upstream reverse proxy strips or replaces the X-Forwarded-For header and
+# the notify_push self-test reports "push server is not a trusted proxy".
+# --allow-self-signed is needed because the TLS cert is issued for the public domain,
+# not the internal container hostname.
+NEXTCLOUD_URL_ARGS=()
+if [ -n "$NOTIFY_PUSH_NEXTCLOUD_URL" ]; then
+    NEXTCLOUD_URL_ARGS=(--nextcloud-url "$NOTIFY_PUSH_NEXTCLOUD_URL" --allow-self-signed)
+fi
+
 # Run it
 exec /var/www/html/custom_apps/notify_push/bin/"$CPU_ARCH"/notify_push \
     --port 7867 \
+    "${NEXTCLOUD_URL_ARGS[@]}" \
     /var/www/html/config/config.php

--- a/nextcloud-aio-helm-chart/templates/nextcloud-aio-notify-push-deployment.yaml
+++ b/nextcloud-aio-helm-chart/templates/nextcloud-aio-notify-push-deployment.yaml
@@ -41,6 +41,10 @@ spec:
               value: nextcloud-aio-nextcloud
             - name: TZ
               value: "{{ .Values.TIMEZONE }}"
+            {{- if .Values.NOTIFY_PUSH_NEXTCLOUD_URL }}
+            - name: NOTIFY_PUSH_NEXTCLOUD_URL
+              value: "{{ .Values.NOTIFY_PUSH_NEXTCLOUD_URL }}"
+            {{- end }}
           image: ghcr.io/nextcloud-releases/aio-notify-push:20260513_090235
           readinessProbe:
             exec:

--- a/php/containers.json
+++ b/php/containers.json
@@ -315,7 +315,8 @@
       "environment": [
         "NEXTCLOUD_HOST=nextcloud-aio-nextcloud",
         "AIO_LOG_LEVEL=%AIO_LOG_LEVEL%",
-        "TZ=%TIMEZONE%"
+        "TZ=%TIMEZONE%",
+        "NOTIFY_PUSH_NEXTCLOUD_URL=%NOTIFY_PUSH_NEXTCLOUD_URL%"
       ],
       "restart": "unless-stopped",
       "read_only": true,

--- a/php/src/Data/ConfigurationManager.php
+++ b/php/src/Data/ConfigurationManager.php
@@ -230,6 +230,11 @@ class ConfigurationManager
         set { $this->set('nextcloud_memory_limit', $value); }
     }
 
+    public string $notifyPushNextcloudUrl {
+        get => $this->getEnvironmentalVariableOrConfig('NOTIFY_PUSH_NEXTCLOUD_URL', 'notify_push_nextcloud_url', '');
+        set { $this->set('notify_push_nextcloud_url', $value); }
+    }
+
     public function getApacheMaxSize() : int {
         $uploadLimit = (int)rtrim($this->nextcloudUploadLimit, 'G');
         return $uploadLimit * 1024 * 1024 * 1024;
@@ -1097,6 +1102,7 @@ class ConfigurationManager
             'HARP_ENABLED' => $this->isHarpEnabled ? 'yes' : '',
             'NEXTCLOUD_UPLOAD_LIMIT' => $this->nextcloudUploadLimit,
             'NEXTCLOUD_MEMORY_LIMIT' => $this->nextcloudMemoryLimit,
+            'NOTIFY_PUSH_NEXTCLOUD_URL' => $this->notifyPushNextcloudUrl,
             'NEXTCLOUD_MAX_TIME' => $this->nextcloudMaxTime,
             'BORG_RETENTION_POLICY' => $this->borgRetentionPolicy,
             'FULLTEXTSEARCH_JAVA_OPTIONS' => $this->fulltextsearchJavaOptions,


### PR DESCRIPTION
## Problem

When an upstream reverse proxy (e.g. Nginx Proxy Manager, HAProxy, OPNsense) **replaces** rather than appends the `X-Forwarded-For` header, the `notify_push` self-test reports:

```
🗴 push server is not a trusted proxy by Nextcloud or another proxy in the chain.
  One of the proxies in the chain seems to have stripped the x-forwarded-for header
  Please configure the reverse proxy at <ip> to not strip the x-forwarded-for header
```

The self-test itself already suggests the fix: _"set the `NEXTCLOUD_URL` environment variable to point directly to the internal Nextcloud webserver url"_. The `notify_push` binary supports `--nextcloud-url` and `--allow-self-signed` flags for exactly this purpose. But there was no way to pass them without manually recreating the container outside of AIO's management.

This is a real scenario for users with a multi-hop reverse proxy chain on a local network, where the innermost proxy strips headers it should be forwarding.

## Solution

Wire `NOTIFY_PUSH_NEXTCLOUD_URL` as a configurable variable following the same pattern as `NEXTCLOUD_MEMORY_LIMIT`:

- Set it via `NOTIFY_PUSH_NEXTCLOUD_URL` env var on the mastercontainer, **or** directly in `configuration.json` as `notify_push_nextcloud_url`
- When set, `start.sh` passes `--nextcloud-url "$NOTIFY_PUSH_NEXTCLOUD_URL" --allow-self-signed` to the binary
- When empty (the default), behaviour is identical to today

**Typical value:** `https://nextcloud-aio-apache` — the push server then reaches Nextcloud directly over the internal Docker network, bypassing the problematic upstream proxy entirely.

## Changes

| File | Change |
|---|---|
| `Containers/notify-push/start.sh` | Pass `--nextcloud-url`/`--allow-self-signed` when env var is set |
| `php/containers.json` | Add `NOTIFY_PUSH_NEXTCLOUD_URL` to notify-push container environment |
| `php/src/Data/ConfigurationManager.php` | Add `notifyPushNextcloudUrl` property + substitution entry |
| `nextcloud-aio-helm-chart/…/nextcloud-aio-notify-push-deployment.yaml` | Add optional env var |

## Testing

With `NOTIFY_PUSH_NEXTCLOUD_URL=https://nextcloud-aio-apache` set, all six self-test checks pass:

```
✓ redis is configured
✓ push server is receiving redis messages
✓ push server can load mount info from database
✓ push server can connect to the Nextcloud server
✓ push server is a trusted proxy
✓ push server is running the same version as the app
```