### PR TITLE
Remove HARP_HOST environment variable from manual-install YAML file

### DIFF
--- a/manual-install/update-yaml.sh
+++ b/manual-install/update-yaml.sh
@@ -48,6 +48,7 @@ sed -i '/AIO_TOKEN/d' containers.yml
 sed -i '/AIO_URL/d' containers.yml
 sed -i '/DOCKER_SOCKET_PROXY_ENABLED/d' containers.yml
 sed -i '/HARP_ENABLED/d' containers.yml
+sed -i '/HARP_HOST/d' containers.yml
 sed -i '/HP_SHARED_KEY/d' containers.yml
 sed -i '/ADDITIONAL_TRUSTED_PROXY/d' containers.yml
 sed -i '/TURN_DOMAIN/d' containers.yml


### PR DESCRIPTION
The `HARP_HOST` env variable seems to be an unintended leftover in the manual install YAML file, since all other HARP-related variables are removed. I can confirm that no issues occur when launching the container without the aforementioned variable.