### PR TITLE
fix(ci): skip helm-release workflow on forks

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   release:
+    if: github.repository == 'nextcloud/all-in-one'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary of Changes

Skip the `helm-release` GitHub Actions workflow when running on forks. The workflow publishes Helm charts to the `gh-pages` branch, which doesn't exist on forks, causing failed workflow runs for contributors who sync their forks.

## Root Cause / What Was Fixed

The `helm-release.yml` workflow triggers on every push to `main` when files under `nextcloud-aio-helm-chart/**` change. On forks, the `helm/chart-releaser-action` fails because:
1. Forks don't have a `gh-pages` branch configured
2. The chart-releaser action tries to create a GitHub Release and publish to `gh-pages`

Added `if: github.repository == 'nextcloud/all-in-one'` condition to the `release` job so it only runs on the upstream repository.

## Testing Done

- Verified the workflow YAML syntax is valid
- The conditional check uses the standard GitHub Actions `github.repository` context, which is well-tested and reliable
- No other workflows are affected by this change

## Related Issue

Fixes #8128