### PR TITLE
fix: prevent uBlock Origin from blocking container log viewer

### DIFF
--- a/php/public/container-log.js
+++ b/php/public/container-log.js
@@ -1,0 +1,142 @@
+class LogViewer {
+    // Configure the interval in seconds for autoloading log data.
+    autoloadIntervalSec = 5;
+    // Set to true to see some debug log statements in the browser console.
+    debugLog = false;
+
+    // Don't touch these, please.
+    containerId;
+    apiBaseUrl = 'api/docker/logs';
+    autoloadIntervalId = null;
+    logElem;
+    lastLogTimestamp = '';
+    autoloadingDisabledFromButton = false;
+    loaderElem;
+    dataLoadingLock;
+
+    constructor() {
+        const id = document.body.dataset.containerId;
+        if (typeof(id) !== 'string' || !id.startsWith('nextcloud-aio-')) {
+            throw new Exception('Invalid container ID');
+        }
+        this.containerId = id;
+        this.logElem = document.querySelector('pre');
+        this.loaderElem = document.querySelector('.loader');
+        this.initAutoloadingControls();
+        // Enable automatic log data loading.
+        this.startAutoloading();
+    }
+
+    startAutoloading() {
+        // Load log data immediately.
+        this.loadAndAppendLogData();
+        // Load new log data repeatedly.
+        this.debug("Starting autoloading");
+        this.autoloadIntervalId = setInterval(() => {
+            if (this.isAutoloadingEnabled()) {
+                this.loadAndAppendLogData();
+            }
+        }, 5000);
+    }
+
+    stopAutoloading() {
+        this.debug("Stopping autoloading");
+        clearInterval(this.autoloadIntervalId);
+        this.autoloadIntervalId = null;
+    }
+
+    isAutoloadingEnabled() {
+        return !!this.autoloadIntervalId;
+    }
+
+    getUrl() {
+        return `${this.apiBaseUrl}?id=${this.containerId}&since=${this.lastLogTimestamp}`;
+    }
+
+    debug(...args) {
+        if (this.debugLog) {
+            console.debug('LogViewer:', ...args);
+        }
+    }
+
+    // Load log data and append it to the DOM.
+    loadAndAppendLogData() {
+        if (this.dataLoadingLock) {
+            this.debug("Another log data loading request is still running, cancelling this request");
+            return;
+        }
+        this.debug("Loading new log data");
+        this.dataLoadingLock = true;
+        this.loaderElem.classList.remove('hidden');
+        fetch(this.getUrl())
+            .then((response) => {
+                if (!response.ok) {
+                    throw new Error("Error while fetching log data!");
+                }
+                return response;
+            })
+            .then((response) => response.text())
+            .then((text) => {
+                text = text.trim();
+                if (text.length === 0) {
+                    this.debug("Received no new log data from server");
+                    return;
+                }
+                this.debug("Received", Math.round(text.length / 1024), "KB of new log data from server");
+                this.logElem.append(text + "\n");
+                this.scrollToBottom();
+                this.lastLogTimestamp = text.split("\n").at(-1)?.split(' ')[0] ?? '';
+            })
+            .finally(() => {
+                this.dataLoadingLock = false;
+                this.loaderElem.classList.add('hidden');
+                this.debug("Finished log data loading");
+            })
+            .catch((err) => console.error(err));
+    }
+
+    scrollToBottom() {
+        this.logElem.scrollTop = this.logElem.scrollHeight;
+    }
+
+    initAutoloadingControls() {
+        // Provide a button that allows to manually disable the autoloading.
+        const button = document.getElementById('autoloading-control');
+        const statusElem = document.getElementById('autoloading-status');
+        if (!button) {
+            return;
+        }
+        button.addEventListener('click', (event) => {
+            event.preventDefault();
+            if (this.isAutoloadingEnabled()) {
+                this.stopAutoloading();
+                statusElem.textContent = 'disabled';
+                button.textContent = 'Enable';
+                this.autoloadingDisabledFromButton = true;
+            } else {
+                this.startAutoloading();
+                statusElem.textContent = 'enabled';
+                button.textContent = 'Disable';
+                this.autoloadingDisabledFromButton = false;
+            }
+        });
+
+        // Load new data immediately if the window gets visible to the user again (unless autoloading has been
+        // disabled).
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState === 'visible') {
+                this.debug("Window became visible");
+                if (!this.autoloadingDisabledFromButton) {
+                    this.startAutoloading();
+                }
+            } else {
+                this.debug("Window became hidden");
+                this.stopAutoloading();
+            }
+        });
+    }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    new LogViewer();
+});

--- a/php/templates/log.twig
+++ b/php/templates/log.twig
@@ -3,7 +3,33 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
         <link rel="stylesheet" href="style.css">
         <link rel="stylesheet" href="logs.css">
-        <script src="log-view.js?v1"></script>
+        <script src="container-log.js?v1"></script>
+        <script>
+            // Detect if the log viewer script failed to load (e.g. blocked by an ad blocker
+            // or browser extension). The LogViewer constructor is defined in container-log.js
+            // and runs on DOMContentLoaded. Show an error if it hasn't initialized after
+            // a short grace period.
+            window.addEventListener('DOMContentLoaded', function() {
+                setTimeout(function() {
+                    // The LogViewer class is defined globally by container-log.js.
+                    // If the script failed to load, typeof LogViewer will be 'undefined'.
+                    if (typeof LogViewer === 'undefined') {
+                        var floatingBox = document.getElementById('floating-box');
+                        if (floatingBox) {
+                            var errorMsg = document.createElement('div');
+                            errorMsg.style.cssText =
+                                'background:#fef2f2;border:1px solid #fecaca;color:#991b1b;' +
+                                'padding:12px 16px;border-radius:6px;margin-top:8px;font-size:14px;';
+                            errorMsg.textContent =
+                                'The log viewer script failed to load. This may be caused by a ' +
+                                'browser extension (such as an ad blocker). Try disabling the ' +
+                                'extension for this page, or use a different browser.';
+                            floatingBox.appendChild(errorMsg);
+                        }
+                    }
+                }, 2000);
+            });
+        </script>
     </head>
     <body data-container-id="{{ id }}">
         <div id="floating-box">


### PR DESCRIPTION
## Summary

Renamed `log-view.js` to `container-log.js` to avoid being blocked by uBlock Origin and similar ad-blocking browser extensions. Added a fallback error message that detects when the script fails to load and guides users to disable ad-blocking extensions or use a different browser.

## Root Cause

uBlock Origin's default filter lists match script filenames containing patterns like `log-view`, causing the container log viewer page to render blank with no error message when an ad blocker is enabled. The user sees only an empty page with the control box.

## Changes

1. **Renamed** `php/public/log-view.js` → `php/public/container-log.js` — the filename `container-log.js` is less likely to match ad-blocker filter patterns.

2. **Updated** `php/templates/log.twig`:
   - Changed the `<script src>` reference to point to the new filename
   - Added an inline detection script that checks whether `LogViewer` is defined after a 2-second grace period
   - If the script failed to load (e.g., blocked by an extension), a red error banner appears inside the floating box explaining the likely cause and suggesting workarounds

## Testing

- Verified the file rename doesn't break the existing functionality (the file content is unchanged)
- The error detection script is passive — it only activates if `LogViewer` is undefined after DOM load, so normal operation is unaffected
- The error message appears within the existing `#floating-box` container, maintaining visual consistency

Fixes #8144