### PR TITLE
docs(reverse-proxy): document X-Forwarded-For requirement for notify_push

### DIFF
--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -188,6 +188,9 @@ The process to run Nextcloud AIO behind a reverse proxy has three required steps
 
     </details>
 
+> [!NOTE]
+> **`X-Forwarded-For` is required for `notify_push`.** The `notify_push` app that powers instant desktop/mobile sync notifications performs a self-test on startup: it sends a request through your reverse proxy and verifies that the `X-Forwarded-For` header arrives at Nextcloud unchanged. If your reverse proxy strips or overwrites this header (e.g. using `proxy_set_header X-Forwarded-For ""` in Nginx), the self-test will fail, and clients will fall back to slow polling-based sync instead of real-time push notifications. The sample configurations below already include the necessary header forwarding — do not remove it. If you use an additional upstream proxy or CDN, make sure it also passes `X-Forwarded-For` through unchanged.
+
 ##### Apache
 
 <details>
@@ -1239,6 +1242,7 @@ If something does not work, follow the steps below:
 1. [Enable Hairpin NAT in your router](https://github.com/nextcloud/all-in-one/discussions/5849) or [set up a local DNS server and add a custom dns-record](https://github.com/nextcloud/all-in-one#how-can-i-access-nextcloud-locally) that allows the server to reach itself locally
 1. Try to configure everything from scratch - if it still does not work by following https://github.com/nextcloud/all-in-one#how-to-properly-reset-the-instance.
 1. As last resort, you may disable the domain validation by adding `--env SKIP_DOMAIN_VALIDATION=true` to the docker run command. But only use this if you are completely sure that you've correctly configured everything! Also see [this documentation](https://github.com/nextcloud/all-in-one#how-to-skip-the-domain-validation).
+1. If desktop/mobile clients receive file change notifications slowly (sync updates only when the client polls, not immediately when a file changes), check whether `notify_push` is healthy by running `sudo docker logs nextcloud-aio-notify-push`. A **"self-test failed"** message means the reverse proxy is stripping the `X-Forwarded-For` header before it reaches Nextcloud. Fix this by ensuring your reverse proxy passes that header through unchanged — see the note in [step 1](#1-configure-the-reverse-proxy).
 
 ### 8. Removing the reverse proxy
 


### PR DESCRIPTION
## What this PR does

Adds two small documentation additions to `reverse-proxy.md` explaining that reverse proxies must not strip the `X-Forwarded-For` header, because `notify_push` relies on it for its startup self-test.

### Context

When `notify_push` starts it performs a self-test: it makes a request through the Nextcloud URL and checks that the `X-Forwarded-For` header it sent arrives at Nextcloud unchanged. If a reverse proxy strips or overwrites this header (e.g. a hardened config using `proxy_set_header X-Forwarded-For ""`), the self-test fails silently. Clients then fall back to slow polling-based sync instead of real-time push notifications — a confusing symptom that's hard to diagnose.

This came up in #8108 (where I originally tried to add a workaround env var). @szaimen correctly pointed out that the right fix is to configure the reverse proxy properly, so this PR just documents that requirement.

### Changes

1. **Note in step 1** (before the proxy-specific configs): explains the header requirement and points users to ensure their proxy passes it through.
2. **New debug step in step 7**: tells users to run `docker logs nextcloud-aio-notify-push` and look for "self-test failed" if push notifications are slow.

The sample configs already do the right thing (Nginx has `proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;`, Caddy passes it automatically) — this just makes the requirement explicit so users don't inadvertently strip it.