### PR TITLE
mastercontainer: run session-deduplicator as www-data

### DIFF
--- a/Containers/mastercontainer/supervisord.conf
+++ b/Containers/mastercontainer/supervisord.conf
@@ -54,7 +54,7 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 command=/session-deduplicator.sh
-user=root
+user=www-data
 
 [program:domain-validator]
 # Logging is disabled as otherwise all attempts will be logged which spams the logs


### PR DESCRIPTION
## Summary
The `session-deduplicator` supervisord program in the mastercontainer currently runs as root, but the script only reads `/mnt/docker-aio-config/data/session_date_file` and deletes/greps files under `/mnt/docker-aio-config/session/` — both already owned by `www-data` via `start.sh`. Switching the program to `user=www-data` drops one more root process from the mastercontainer without changing behaviour.

## Changes
- `Containers/mastercontainer/supervisord.conf`: change `user=root` to `user=www-data` in the `[program:session-deduplicator]` block.

## Testing
No automated tests exist for the mastercontainer supervisord programs or shell scripts in this repo. Verified by inspection: `start.sh` recursively `chown`s `/mnt/docker-aio-config/session/` and the parent config directory (which contains `session_date_file`) to `www-data`, so the script's `rm`, `grep`, and `cat` operations have the required permissions under the new user.

## Notes
Other supervisord programs in the same file (e.g. `notify_push`, `domain-validator`) still run as root; narrowing those is out of scope for this issue.

Closes #8164