### PR TITLE
revert: caddy: use acme shortlived profile

### DIFF
--- a/Containers/apache/Caddyfile
+++ b/Containers/apache/Caddyfile
@@ -78,7 +78,6 @@ http://{$APACHE_HOST}.nextcloud-aio:23973, # For Collabora callback and WOPI req
     # TLS options
     tls {
         issuer acme {
-            profile shortlived
             # Disable HTTP challenge because that would require port 80, which we don't get (it's exposed to the mastercontainer).
             # This container by default only exposes port 443 if not configured otherwise via APACHE_PORT.
             disable_http_challenge

--- a/Containers/mastercontainer/acme.Caddyfile
+++ b/Containers/mastercontainer/acme.Caddyfile
@@ -49,7 +49,6 @@ https://:8443 {
 	tls {
 		on_demand
 		issuer acme {
-            profile shortlived
 			disable_tlsalpn_challenge
 		}
 	}


### PR DESCRIPTION
- Fixes https://help.nextcloud.com/t/aio-update-to-nextcloud-aio-v13-1-0-downgrades-lets-encrypt-certificates-to-one-week/245206
- reverts https://github.com/nextcloud/all-in-one/pull/7823
- reason: currently talk will show a warning regularly if the cert expires in a few days: https://github.com/nextcloud/all-in-one/pull/7823#issuecomment-4518082615
- Needs https://github.com/nextcloud/spreed/issues/17306
