### PR TITLE
caddy: re-introduce lets encrypt profiles

### DIFF
--- a/Containers/apache/Caddyfile
+++ b/Containers/apache/Caddyfile
@@ -78,6 +78,7 @@ http://{$APACHE_HOST}.nextcloud-aio:23973, # For Collabora callback and WOPI req
     # TLS options
     tls {
         issuer acme {
+            profile tlsserver
             # Disable HTTP challenge because that would require port 80, which we don't get (it's exposed to the mastercontainer).
             # This container by default only exposes port 443 if not configured otherwise via APACHE_PORT.
             disable_http_challenge

--- a/Containers/mastercontainer/acme.Caddyfile
+++ b/Containers/mastercontainer/acme.Caddyfile
@@ -49,6 +49,7 @@ https://:8443 {
 	tls {
 		on_demand
 		issuer acme {
+            profile shortlived
 			disable_tlsalpn_challenge
 		}
 	}


### PR DESCRIPTION
- Close https://github.com/nextcloud/all-in-one/issues/8236