### PR TITLE
talk-recording: adjust listen address back to 0.0.0.0 as talk-recording listen address does not officially support ipv6 yet

### DIFF
--- a/Containers/talk-recording/healthcheck.sh
+++ b/Containers/talk-recording/healthcheck.sh
@@ -4,4 +4,4 @@ if [ "$AIO_LOG_LEVEL" = 'debug' ]; then
     set -x
 fi
 
-nc -z 127.0.0.1 1234 || nc -z ::1 1234 || exit 1
+nc -z 127.0.0.1 1234 || exit 1

--- a/Containers/talk-recording/start.sh
+++ b/Containers/talk-recording/start.sh
@@ -58,21 +58,13 @@ extensionaudio = .m4a
 extensionvideo = .mp4"
 fi
 
-# Detect IPv6 availability to choose the right listen address
-RECORDING_LISTEN="0.0.0.0:1234"
-if ! grep -q "1" /sys/module/ipv6/parameters/disable 2>/dev/null \
-&& ! grep -q "1" /proc/sys/net/ipv6/conf/all/disable_ipv6 2>/dev/null \
-&& ! grep -q "1" /proc/sys/net/ipv6/conf/default/disable_ipv6 2>/dev/null; then
-    RECORDING_LISTEN="[::]:1234"
-fi
-
 cat << RECORDING_CONF > "/conf/recording.conf"
 [logs]
 # 30 means Warning
 level = ${TALK_RECORDING_LOG_LEVEL}
 
 [http]
-listen = ${RECORDING_LISTEN}
+listen = 0.0.0.0:1234
 
 [backend]
 allowall = ${ALLOW_ALL}


### PR DESCRIPTION
- Follow-up to https://github.com/nextcloud/all-in-one/pull/8019
- [ ] The PR was tested and verified that it works locally
- [ ] The PR was completely or partially created with AI
