### PR TITLE
doc: add missing proxy header in reverse-proxy.md

### DIFF
--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -523,6 +523,7 @@ server {
     location / {
         proxy_pass http://127.0.0.1:11000$request_uri; # Adjust to match APACHE_PORT and APACHE_IP_BINDING. See https://github.com/nextcloud/all-in-one/blob/main/reverse-proxy.md#adapting-the-sample-web-server-configurations-below
 
+        proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Port $server_port;
         proxy_set_header X-Forwarded-Scheme $scheme;


### PR DESCRIPTION
- fix: add missing nginx proxy header
- close https://github.com/nextcloud/all-in-one/issues/8259
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

<!-- Please check the below checkmarks if applicable -->

- [x] The PR was tested and verified that it works locally
- [ ] The PR was completely or partially created with AI
