### PR TITLE
fix(nextcloud): register EuroOffice preview provider

### DIFF
--- a/Containers/nextcloud/entrypoint.sh
+++ b/Containers/nextcloud/entrypoint.sh
@@ -908,6 +908,12 @@ if [ "$EUROOFFICE_ENABLED" = 'yes' ]; then
         fi
 
         php /var/www/html/occ config:app:set eurooffice DocumentServerUrl --value="https://$EUROOFFICE_HOST"
+
+        # Register EuroOffice preview provider in the explicit allowlist.
+        # Use a high fixed index (50) to avoid colliding with AIO's seeded indices (1-7, 23).
+        if ! php /var/www/html/occ config:system:get enabledPreviewProviders | grep -q "Eurooffice"; then
+            php /var/www/html/occ config:system:set enabledPreviewProviders 50 --value="OCA\Eurooffice\Preview"
+        fi
     fi
 else
     # Remove EuroOffice app if disabled and removal is requested

--- a/Containers/nextcloud/entrypoint.sh
+++ b/Containers/nextcloud/entrypoint.sh
@@ -912,7 +912,7 @@ if [ "$EUROOFFICE_ENABLED" = 'yes' ]; then
         # Register EuroOffice preview provider in the explicit allowlist.
         # Use a high fixed index (50) to avoid colliding with AIO's seeded indices (1-7, 23).
         if ! php /var/www/html/occ config:system:get enabledPreviewProviders | grep -q "Eurooffice"; then
-            php /var/www/html/occ config:system:set enabledPreviewProviders 50 --value="OCA\Eurooffice\Preview"
+            php /var/www/html/occ config:system:set enabledPreviewProviders 24 --value="OCA\Eurooffice\Preview"
         fi
     fi
 else


### PR DESCRIPTION
- [x] The PR was tested and verified that it works locally
- [x] The PR was completely or partially created with AI

---

## Summary

Registers the EuroOffice preview provider in `enabledPreviewProviders` so that office document thumbnails are generated correctly.

**Change:**
- Adds `OCA\Eurooffice\Preview` at index 50 to avoid colliding with AIO's seeded indices (1–7, 23). The check is idempotent.

## Test plan

- [ ] Office document thumbnails appear in the Files list
- [ ] Office document thumbnails appear in the recommendation widget
- [ ] Re-running the entrypoint is a no-op (idempotency check)

## Related PRs

- **#8290** — Caddyfile `X-Forwarded-Prefix` header fix
- **#8289** — Make EuroOffice the default editor for new installs