### PR TITLE
fix(apache): send X-Forwarded-Prefix for EuroOffice SDK assets

### DIFF
--- a/Containers/apache/Caddyfile
+++ b/Containers/apache/Caddyfile
@@ -54,7 +54,8 @@ http://{$APACHE_HOST}.nextcloud-aio:23973, # For Collabora callback and WOPI req
     route /eurooffice/* {
         uri strip_prefix /eurooffice
         reverse_proxy {$EUROOFFICE_HOST}:80 {
-            header_up X-Forwarded-Host {http.request.hostport}/eurooffice
+            header_up X-Forwarded-Host {http.request.hostport}
+            header_up X-Forwarded-Prefix /eurooffice
         }
     }
 

--- a/Containers/apache/Caddyfile
+++ b/Containers/apache/Caddyfile
@@ -54,7 +54,6 @@ http://{$APACHE_HOST}.nextcloud-aio:23973, # For Collabora callback and WOPI req
     route /eurooffice/* {
         uri strip_prefix /eurooffice
         reverse_proxy {$EUROOFFICE_HOST}:80 {
-            header_up X-Forwarded-Host {http.request.hostport}
             header_up X-Forwarded-Prefix /eurooffice
         }
     }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

<!-- Please check the below checkmarks if applicable -->

- [x] The PR was tested and verified that it works locally
- [x] The PR was completely or partially created with AI

---

## Summary

Fixes the Apache reverse-proxy config for the EuroOffice route so that the EuroOffice SDK can correctly resolve its own asset paths when served under the `/eurooffice` sub-path.

- Replaces the incorrect `X-Forwarded-Host` override (which leaked the host+port+path into the `Host` header) with the correct `X-Forwarded-Prefix: /eurooffice` header
- Removes the now-redundant duplicate `X-Forwarded-Host` directive added in a previous commit

## Test plan

- [ ] EuroOffice loads and opens documents without broken asset requests in the browser network tab
- [ ] No regressions for Collabora or OnlyOffice routes

## Related PRs

This is one of three PRs for EuroOffice integration fixes (can be merged independently):

- **This PR (#8290)** — Caddyfile `X-Forwarded-Prefix` header fix
- **#8288** — Set internal Docker URLs for server-to-server calls (fixes thumbnails in recommendation widget)
- **#8289** — Make EuroOffice the default editor for new and existing installs