### PR TITLE
Add X-Forwarded-Proto to support Euro-office on Apache reverse proxy

### DIFF
--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -218,6 +218,8 @@ Add this as a new Apache site config:
     RewriteEngine On
     ProxyPreserveHost On
     RequestHeader set X-Real-IP %{REMOTE_ADDR}s
+    # Added to support Euro-office
+    RequestHeader set X-Forwarded-Proto "https"
     AllowEncodedSlashes NoDecode
     
     # Adjust the two lines below to match APACHE_PORT and APACHE_IP_BINDING. See https://github.com/nextcloud/all-in-one/blob/main/reverse-proxy.md#adapting-the-sample-web-server-configurations-below


### PR DESCRIPTION
I has a similar issue as mentioned in #8291 but I'm using Apache as a reverse proxy. This configuration works for me.

<!-- Please check the below checkmarks if applicable -->

- [x] The PR was tested and verified that it works locally
- [ ] The PR was completely or partially created with AI
