### PR TITLE
allow install_latest_major to be set to "no" 

### DIFF
--- a/php/src/Data/ConfigurationManager.php
+++ b/php/src/Data/ConfigurationManager.php
@@ -1115,7 +1115,7 @@ class ConfigurationManager
             'NEXTCLOUD_STARTUP_APPS' => $this->getNextcloudStartupApps(),
             'NEXTCLOUD_ADDITIONAL_APKS' => $this->nextcloudAdditionalApks,
             'NEXTCLOUD_ADDITIONAL_PHP_EXTENSIONS' => $this->nextcloudAdditionalPhpExtensions,
-            'INSTALL_LATEST_MAJOR' => $this->installLatestMajor ? 'yes' : '',
+            'INSTALL_LATEST_MAJOR' => ($this->installLatestMajor !== '' && $this->installLatestMajor !== 'no') ? 'yes' : '',
             'REMOVE_DISABLED_APPS' => $this->nextcloudKeepDisabledApps ? '' : 'yes',
             // Allow to get local ip-address of database container which allows to talk to it even in host mode (the container that requires this needs to be started first then)
             'AIO_DATABASE_HOST' => NetworkHelper::resolveHostname('nextcloud-aio-database'),


### PR DESCRIPTION
  Previously the mapping was just $this->installLatestMajor ? 'yes' : '', so a stored value of 'no' was truthy and would have been turned into INSTALL_LATEST_MAJOR=yes in the Nextcloud container — the opposite of what the user intended. Now both ''

  and 'no' result in an empty env value, which the entrypoint's [ "$INSTALL_LATEST_MAJOR" = yes ] check treats as disabled, while any other value (e.g. the '34' set by the start button or upgrade button) still maps to yes.

  Assisted-by: Claude

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

<!-- Please check the below checkmarks if applicable -->

- [ ] The PR was tested and verified that it works locally
- [x] The PR was completely or partially created with AI
