### PR TITLE
DockerActionManager: Fix fetching logs initially on podman

### DIFF
--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -169,12 +169,11 @@ readonly class DockerActionManager {
     }
 
     public function GetLogs(string $id, string $since = ''): string {
-        $url = $this->BuildApiUrl(
-            sprintf(
-                'containers/%s/logs?stdout=true&stderr=true&timestamps=true&since=%s',
-                urlencode($id),
-                $since
-            ));
+        $path = sprintf('containers/%s/logs?stdout=true&stderr=true&timestamps=true', urlencode($id));
+        if ($since !== '') {
+            $path .= sprintf('&since=%s', $since);
+        }
+        $url = $this->BuildApiUrl($path);
         $responseBody = (string)$this->sendHttpRequest('GET', $url)->getBody();
 
         $response = "";


### PR DESCRIPTION
Podman doesn't like an empty `since` URL parameter, so the initial log fetching fails.

This change sends the parameter only if it has a non-empty value and thus fixes that problem.

- [x] The PR was tested and verified that it works locally
- [ ] The PR was completely or partially created with AI
