### PR TITLE
feat(fail2ban): expose FAIL2BAN_IGNOREIPS env var in AIO interface

### DIFF
--- a/community-containers/fail2ban/fail2ban.json
+++ b/community-containers/fail2ban/fail2ban.json
@@ -13,7 +13,8 @@
                 "NET_RAW"
             ],
             "environment": [
-                "TZ=%TIMEZONE%"
+                "TZ=%TIMEZONE%",
+                "FAIL2BAN_IGNOREIPS=%FAIL2BAN_IGNOREIPS%"
             ],
             "volumes": [
                 {


### PR DESCRIPTION
- Allows admins to whitelist custom IPs (e.g. office IPs, VPN ranges)
- Passes through to the fail2ban community container
- Requires corresponding change in szaimen/aio-fail2ban (env var is a no-op without it)

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

<!-- Please check the below checkmarks if applicable -->

- [x] The PR was tested and verified that it works locally
- [x] The PR was partially created with AI, DeepSeek v4 Pro
