### PR TITLE
apache: re-introduce `X-Forwarded-Proto https` so that onlyoffice and eurooffice always work no matter the actual reverse proxy config in front of it

### DIFF
--- a/Containers/apache/Caddyfile
+++ b/Containers/apache/Caddyfile
@@ -55,7 +55,6 @@ http://{$APACHE_HOST}.nextcloud-aio:23973, # For Collabora callback and WOPI req
     route /eurooffice/* {
         uri strip_prefix /eurooffice
         reverse_proxy {$EUROOFFICE_HOST}:80 {
-            header_up X-Forwarded-Host {http.request.hostport}
             header_up X-Forwarded-Prefix /eurooffice
             header_up X-Forwarded-Proto https
         }

--- a/Containers/apache/Caddyfile
+++ b/Containers/apache/Caddyfile
@@ -47,6 +47,7 @@ http://{$APACHE_HOST}.nextcloud-aio:23973, # For Collabora callback and WOPI req
         uri strip_prefix /onlyoffice
         reverse_proxy {$ONLYOFFICE_HOST}:80 {
             header_up X-Forwarded-Host {http.request.hostport}/onlyoffice
+            header_up X-Forwarded-Proto https
         }
     }
 
@@ -54,7 +55,9 @@ http://{$APACHE_HOST}.nextcloud-aio:23973, # For Collabora callback and WOPI req
     route /eurooffice/* {
         uri strip_prefix /eurooffice
         reverse_proxy {$EUROOFFICE_HOST}:80 {
+            header_up X-Forwarded-Host {http.request.hostport}
             header_up X-Forwarded-Prefix /eurooffice
+            header_up X-Forwarded-Proto https
         }
     }
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

<!-- Please check the below checkmarks if applicable -->

- [ ] The PR was tested and verified that it works locally
- [ ] The PR was completely or partially created with AI
