### PR TITLE
Save default container selection on setup.

### DIFF
--- a/.github/workflows/playwright-on-push.yml
+++ b/.github/workflows/playwright-on-push.yml
@@ -30,6 +30,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Run Playwright test for persisted defaults
+        run: ./php/tests/run.sh ./php/tests/tests/persist-default-config.spec.js
+
       - name: Run Playwright tests for initial setup
         run: ./php/tests/run.sh ./php/tests/tests/initial-setup.spec.js
         env:

--- a/.github/workflows/playwright-on-workflow-dispatch.yml
+++ b/.github/workflows/playwright-on-workflow-dispatch.yml
@@ -19,6 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Run Playwright test for persisted defaults
+        env:
+          TEST_CODE_FROM_IMAGE: yes
+        run: ./php/tests/run.sh ./php/tests/tests/persist-default-config.spec.js
+
       - name: Run Playwright tests for initial setup
         env:
           TEST_CODE_FROM_IMAGE: yes

--- a/php/src/Data/Setup.php
+++ b/php/src/Data/Setup.php
@@ -18,7 +18,23 @@ readonly class Setup {
         }
 
         $password = $this->passwordGenerator->GeneratePassword(8);
+        // Save the password and the default container selection to the config, so it gets persisted even if
+        // people don't change anything in the UI. Without this any change to the defaults would be applied to
+        // existing instances.
+        $this->configurationManager->startTransaction();
         $this->configurationManager->password = $password;
+        // Get the defaults for these config options from their own getters to avoid duplication of defaults.
+        // Makes the code look funny but works.
+        $this->configurationManager->officeSuite = $this->configurationManager->officeSuite;
+        $this->configurationManager->isClamavEnabled = $this->configurationManager->isClamavEnabled;
+        $this->configurationManager->isFulltextsearchEnabled = $this->configurationManager->isFulltextsearchEnabled;
+        $this->configurationManager->isImaginaryEnabled = $this->configurationManager->isImaginaryEnabled;
+        $this->configurationManager->isTalkEnabled = $this->configurationManager->isTalkEnabled;
+        $this->configurationManager->isTalkRecordingEnabled = $this->configurationManager->isTalkRecordingEnabled;
+        $this->configurationManager->isDockerSocketProxyEnabled = $this->configurationManager->isDockerSocketProxyEnabled;
+        $this->configurationManager->isHarpEnabled = $this->configurationManager->isHarpEnabled;
+        $this->configurationManager->isWhiteboardEnabled = $this->configurationManager->isWhiteboardEnabled;
+        $this->configurationManager->commitTransaction();
         return $password;
     }
 

--- a/php/tests/compose.yaml
+++ b/php/tests/compose.yaml
@@ -76,6 +76,7 @@ services:
     image: mcr.microsoft.com/playwright:v1.56.1@sha256:f1e7e01021efd65dd1a2c56064be399f3e4de00fd021ac561325f2bfbb2b837a
     volumes:
       - ..:/app
+      - nextcloud_aio_mastercontainer:/mnt/docker-aio-config:ro
     working_dir: /app/tests
     ports:
       - '9323:9323' # to view test reports
@@ -114,4 +115,3 @@ services:
 volumes:
   nextcloud_aio_mastercontainer:
     name: nextcloud_aio_mastercontainer
-

--- a/php/tests/run.sh
+++ b/php/tests/run.sh
@@ -27,10 +27,9 @@ run_tests() {
     fi
     
     # Clean up old containers and volumes
+    $DOCO --profile $profile down -v --remove-orphans
     docker container rm --force nextcloud-aio-{mastercontainer,apache,notify-push,nextcloud,redis,database,domaincheck,whiteboard,imaginary,talk,collabora,borgbackup} > /dev/null 2>&1
     docker volume rm nextcloud_aio_{mastercontainer,apache,database,database_dump,nextcloud,nextcloud_data,redis,backup_cache,elasticsearch} > /dev/null 2>&1
-    $DOCO --profile $profile down -v
-    sleep 1
 
     echo -e "\n 📣  Running playwright tests for ${TESTS_FILE} with SKIP_DOMAIN_VALIDATION=$SKIP_DOMAIN_VALIDATION and profile '$profile'\n"
     $DOCO --profile $profile run --remove-orphans test-runner-$profile
@@ -63,6 +62,9 @@ if [[ -n "$1" ]]; then
     fi
     run_tests "$relpath"
 else
+    SKIP_DOMAIN_VALIDATION=false
+    run_tests tests/persist-default-config.spec.js
+    sleep 1
     SKIP_DOMAIN_VALIDATION=true
     run_tests tests/initial-setup.spec.js
     sleep 1

--- a/php/tests/tests/persist-default-config.spec.js
+++ b/php/tests/tests/persist-default-config.spec.js
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+
+test('Initial setup persists default container selections', async ({ page: setupPage }) => {
+  test.setTimeout(10 * 60 * 1000);
+
+  await setupPage.goto('./setup');
+
+  await expect.poll(() => {
+    try {
+        return JSON.parse(readFileSync('/mnt/docker-aio-config/data/configuration.json', 'utf8'));
+    } catch {
+        return null;
+    }
+  }, { timeout: 30_000 }).toMatchObject({
+    officeSuite: 'eurooffice',
+    isClamavEnabled: false,
+    isTalkEnabled: true,
+    isTalkRecordingEnabled: false,
+    isImaginaryEnabled: true,
+    isFulltextsearchEnabled: false,
+    isDockerSocketProxyEnabled: false,
+    isHarpEnabled: false,
+    isWhiteboardEnabled: true,
+  });
+});


### PR DESCRIPTION
Save the default container selection to the config, so it gets persisted even
if people don't change anything in the UI. Without this any change to the
defaults would be applied to existing instances.

- Resolves: # <!-- related github issue -->

## Summary
- [x] The PR was tested and verified that it works locally
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests (playwright if possible) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation has been updated or is not required
- [x] [Labels added](https://github.com/nextcloud/all-in-one/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone next added](https://github.com/nextcloud/all-in-one/milestones)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
