### PR TITLE
fix(local-ai): enable NVIDIA GPU passthrough

### DIFF
--- a/community-containers/local-ai/local-ai.json
+++ b/community-containers/local-ai/local-ai.json
@@ -47,6 +47,7 @@
             "devices": [
                 "/dev/dri"
             ],
+            "enable_nvidia_gpu": true,
             "nextcloud_exec_commands": [
                 "php /var/www/html/occ app:install integration_openai",
                 "php /var/www/html/occ app:enable integration_openai",


### PR DESCRIPTION
## Summary
- The `local-ai` community container only requests `/dev/dri`, which is the Mesa/AMD/Intel Vulkan device passthrough mechanism.
- On NVIDIA-only hosts (no Mesa-compatible device), Vulkan has nothing to bind to and every backend (llama-cpp, stablediffusion-ggml, whisper) silently falls back to `llvmpipe` (CPU-only software rendering).
- This makes image generation in particular unusably slow — CPU-based Stable Diffusion routinely took 2+ minutes per image in my testing, exceeding `integration_openai`'s `image_request_timeout` (240s default) and causing Assistant sticker/image tasks to fail outright.
- `plex`, `jellyfin`, and `memories` already solve this for their own GPU-accelerated use cases via `"enable_nvidia_gpu": true`, which `DockerActionManager` turns into `Runtime: nvidia` + the correct `DeviceRequests` when the host operator has set `NEXTCLOUD_ENABLE_NVIDIA_GPU=true` on the mastercontainer. `local-ai.json` was missing this flag.

## Change
- Add `"enable_nvidia_gpu": true` to `community-containers/local-ai/local-ai.json`, alongside the existing `"devices": ["/dev/dri"]` (same pattern as `memories.json`, so Mesa-only hosts are unaffected and NVIDIA hosts now get real acceleration).

## Testing
Reproduced and fixed on an NVIDIA RTX 5070 host:
- Before: `vulkaninfo` inside the container showed only `llvmpipe` (`PHYSICAL_DEVICE_TYPE_CPU`); a 512x512 SD1.5 image generation took 140s+ (cold) and still exceeded the timeout under normal load.
- After (host operator sets `NEXTCLOUD_ENABLE_NVIDIA_GPU=true` on the mastercontainer + has `nvidia-container-toolkit` installed/configured): `vulkaninfo` correctly reports the `NVIDIA GeForce RTX 5070` (`PHYSICAL_DEVICE_TYPE_DISCRETE_GPU`), and the same image generation completed in 4.5s once the backend was warm, with `nvidia-smi` confirming the stablediffusion-ggml process resident on the GPU.
- Verified `local-ai.json` still validates against `php/containers-schema.json` (the `enable_nvidia_gpu` boolean property already exists in the schema, used by the other GPU-enabled community containers).

## Notes
- This is opt-in: nothing changes unless the host operator explicitly sets `NEXTCLOUD_ENABLE_NVIDIA_GPU=true` on the mastercontainer (per the existing hardware-acceleration docs in the main readme) and has the NVIDIA Container Toolkit installed. Mesa/AMD/Intel-only hosts are unaffected since `/dev/dri` passthrough is untouched.

🤖 Drafted with [Claude Code](https://claude.com/claude-code)
