### PR TITLE
Update Eurooffice container base image to v9.3.2

### DIFF
--- a/Containers/eurooffice/Dockerfile
+++ b/Containers/eurooffice/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:latest
-FROM ghcr.io/euro-office/documentserver:v9.3.1-beta.1
+FROM ghcr.io/euro-office/documentserver:v9.3.2
 
 # USER root is probably used
 


### PR DESCRIPTION
Updating the base image manually, since dependabot appears to ignore or fail on it.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud AIO instances and users in the meantime.
-->

## Summary
- [x] The PR was tested and verified that it works locally
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests (playwright if possible) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation has been updated or is not required
- [x] [Labels added](https://github.com/nextcloud/all-in-one/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone next added](https://github.com/nextcloud/all-in-one/milestones)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
