### PR TITLE
Fix running skopeo in update test containers script

### DIFF
--- a/.github/workflows/update-test-container-image-references.yml
+++ b/.github/workflows/update-test-container-image-references.yml
@@ -14,7 +14,10 @@ jobs:
     - name: Install skopeo
       run: sudo apt-get install -y skopeo
     - name: Run update script
-      run: python3 .ci/update-test-container-image-reference.py
+      run: |
+          # Avoid skopeo trying to write to /run/containers/$USER_ID, which it isn't allowed to do in this context.
+          export REGISTRY_AUTH_FILE="$(mktemp)"
+          python3 .ci/update-test-container-image-reference.py
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v7
       with:


### PR DESCRIPTION
Without this skopeo tries to create /run/containers, which it isn't allowed to do in GitHub's CI context.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud AIO instances and users in the meantime.
-->

- Resolves: # <!-- related github issue -->

## Summary
- [ ] The PR was tested and verified that it works locally
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests (playwright if possible) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation has been updated or is not required
- [x] [Labels added](https://github.com/nextcloud/all-in-one/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone next added](https://github.com/nextcloud/all-in-one/milestones)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
