### PR TITLE
fix(local-ai): correct healthcheck endpoint port

### DIFF
--- a/community-containers/local-ai/local-ai.json
+++ b/community-containers/local-ai/local-ai.json
@@ -14,7 +14,8 @@
                 "LOCALAI_ADDRESS=:10078",
                 "LOCALAI_CONFIG_DIR=/configuration",
                 "LOCALAI_MODEL_PATH=/models",
-                "LOCALAI_BACKEND_PATH=/backends"
+                "LOCALAI_BACKEND_PATH=/backends",
+                "HEALTHCHECK_ENDPOINT=http://localhost:10078/readyz"
             ],
             "ports": [
                 {


### PR DESCRIPTION
## Summary
- `nextcloud-aio-local-ai` (community container, `ghcr.io/docjyj/aio-local-ai-vulkan`) reports `unhealthy` indefinitely even when the service is functioning normally and serving requests.
- The image's default `HEALTHCHECK` probes `http://localhost:8080/readyz`, but LocalAI is configured via `LOCALAI_ADDRESS=:10078` and actually listens on port `10078` (confirmed in the container's own startup log: `LocalAI is started and running address=":10078"`, and in the port mapping).
- Adds an explicit `HEALTHCHECK_ENDPOINT=http://localhost:10078/readyz` env var to override the image's default and point the health check at the correct port.

Observed in production: 977 consecutive failed health checks over ~16 hours while `/models`, `/chat/completions`, and `/images/generations` all returned `200`.

## Test plan
- [x] Validated `community-containers/local-ai/local-ai.json` is well-formed JSON
- [ ] Maintainers/CI to confirm `HEALTHCHECK_ENDPOINT` is respected by `ghcr.io/docjyj/aio-local-ai-vulkan` (env var support confirmed via image's healthcheck script convention, not exhaustively verified against image source)