### PR TITLE
Persist EuroOffice DATA_DIR as a volume

### DIFF
--- a/php/containers-schema.json
+++ b/php/containers-schema.json
@@ -216,7 +216,7 @@
 							"properties": {
 								"destination": {
 									"type": "string",
-									"pattern": "^((/[a-z_/.-]+)|(%[A-Z_]+%))$"
+									"pattern": "^((/[a-zA-Z_/.-]+)|(%[A-Z_]+%))$"
 								},
 								"source": {
 									"type": "string",

--- a/php/containers.json
+++ b/php/containers.json
@@ -795,7 +795,15 @@
           "source": "nextcloud_aio_eurooffice",
           "destination": "/var/lib/euro-office",
           "writeable": true
+        },
+        {
+          "source": "nextcloud_aio_eurooffice_data",
+          "destination": "/var/www/euro-office/Data",
+          "writeable": true
         }
+      ],
+      "backup_volumes": [
+        "nextcloud_aio_eurooffice_data"
       ],
       "secrets": [
         "EUROOFFICE_SECRET"


### PR DESCRIPTION
- Resolves: the persistence gap discussed in #8493

The euro-office image intends `/var/www/euro-office/Data` to be persistent: its entrypoint stores the generated JWT secret and WOPI keys there and prints *"Mount ${DATA_DIR} as a volume to persist it across restarts"*, and `documentserver-generate-allfonts.sh` scans `Data/custom-fonts` on every container start. Without a volume, custom fonts and the generated secrets are lost whenever the container is recreated on update.

This PR mounts a dedicated `nextcloud_aio_eurooffice_data` volume at that path and adds it to `backup_volumes` — it is small (keys + fonts), unlike the deliberately unbackuped, reinstallable documentserver volume. The schema's destination pattern is extended to allow capital letters, since the `Data` directory inside the image is capitalized.

Existing installations pick the volume up on the next container recreation; Docker seeds it from the image content, so behavior is unchanged for users who never added fonts.

## Summary
- [x] The PR was tested and verified that it works locally — *partially: JSON schema validation passes locally (`check-jsonschema`), and the runtime mechanism (entrypoint picking up `Data/custom-fonts` on every start, fonts rendering) is verified on a production AIO instance where we placed the fonts manually. A full run of the patched mastercontainer was not performed.*
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests (playwright if possible) are included — *container-definition change, no UI surface*
- [ ] Screenshots before/after for front-end changes — *n/a*
- [x] Documentation has been updated or is not required
- [x] Labels added — *no permission as outside contributor*
- [x] Milestone next added — *no permission as outside contributor*

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
