### PR TITLE
apache: enable zstd and gzip compression in caddy and disable brotli

### DIFF
--- a/Containers/apache/Caddyfile
+++ b/Containers/apache/Caddyfile
@@ -25,6 +25,8 @@ http://{$APACHE_HOST}.nextcloud-aio:23973, # For Collabora callback and WOPI req
         -Via
     }
 
+    encode
+
     # Collabora
     route /browser/* {
         reverse_proxy {$COLLABORA_HOST}:9980

--- a/Containers/apache/Dockerfile
+++ b/Containers/apache/Dockerfile
@@ -47,7 +47,6 @@ RUN set -ex; \
             -e 's/^#\(LoadModule .*mod_authz_core.so\)/\1/' \
             -e 's/^#\(LoadModule .*mod_alias.so\)/\1/' \
             -e 's/^#\(LoadModule .*mod_mpm_event.so\)/\1/' \
-            -e 's/^#\(LoadModule .*mod_brotli.so\)/\1/' \
             -e 's/\(LoadModule .*mod_mpm_worker.so\)/#\1/' \
             -e 's/\(LoadModule .*mod_mpm_prefork.so\)/#\1/' \
             -e 's/\(ScriptAlias \)/#\1/' \

--- a/Containers/apache/nextcloud.conf
+++ b/Containers/apache/nextcloud.conf
@@ -17,14 +17,6 @@ Listen 8000
     <Proxy "fcgi://${NEXTCLOUD_HOST}:9000" flushpackets=on>
     </Proxy>
 
-    # Compress JS, CSS and SVG responses with Brotli.
-    # Other plain-text files are already compressed by Nextcloud itself.
-    # Desktop and mobile sync clients never request JS/CSS/SVG assets.
-    <IfModule mod_brotli.c>
-        AddOutputFilterByType BROTLI_COMPRESS text/javascript application/javascript application/x-javascript text/css image/svg+xml
-        BrotliCompressionQuality 0
-    </IfModule>
-
     # Nextcloud dir
     DocumentRoot /var/www/html/
     <Directory /var/www/html/>

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ Included are:
 - PHP and web server timeouts set to 3600s, [adjustable](https://github.com/nextcloud/all-in-one#how-to-adjust-the-max-execution-time-for-nextcloud) (important for big file uploads)
 - Defaults to a max of 512 MB RAM per PHP process, [adjustable](https://github.com/nextcloud/all-in-one#how-to-adjust-the-php-memory-limit-for-nextcloud)
 - Automatic TLS included (by using Let's Encrypt)
-- zstd/gzip compression enabled by default for javascript, css and svg files which reduces Nextcloud load times
+- zstd/gzip compression enabled by default inside caddy inside the apache container
 - HTTP/2 and HTTP/3 enabled
 - "Pretty URLs" for Nextcloud are enabled by default (removes the index.php from all links)
 - Video previews work out of the box and when Imaginary is enabled, many recent image formats as well!

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ Included are:
 - PHP and web server timeouts set to 3600s, [adjustable](https://github.com/nextcloud/all-in-one#how-to-adjust-the-max-execution-time-for-nextcloud) (important for big file uploads)
 - Defaults to a max of 512 MB RAM per PHP process, [adjustable](https://github.com/nextcloud/all-in-one#how-to-adjust-the-php-memory-limit-for-nextcloud)
 - Automatic TLS included (by using Let's Encrypt)
-- Brotli compression enabled by default for javascript, css and svg files which reduces Nextcloud load times
+- zstd/gzip compression enabled by default for javascript, css and svg files which reduces Nextcloud load times
 - HTTP/2 and HTTP/3 enabled
 - "Pretty URLs" for Nextcloud are enabled by default (removes the index.php from all links)
 - Video previews work out of the box and when Imaginary is enabled, many recent image formats as well!


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud AIO instances and users in the meantime.
-->

- Resolves: https://github.com/nextcloud/all-in-one/discussions/2574#discussioncomment-11609434

Some Explanation:
 - by letting caddy compress responses also eurooffice and other paths etc will be compressed
 - caddy and apache only compress if the client sends the accept-encoding header which needs to mention zstd or gzip support by the client
 - if a backend response already contains the content-encoding header, then caddy will not compress the response again
 - zstd is the "best" compression algorithm, gzip the worst and brotli in the middle
 - for browser support: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Encoding#browser_compatibility
 - also see: https://caddyserver.com/docs/caddyfile/directives/encode

## Summary
- [x] The PR was tested and verified that it works locally
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests (playwright if possible) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation has been updated or is not required
- [x] [Labels added](https://github.com/nextcloud/all-in-one/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone next added](https://github.com/nextcloud/all-in-one/milestones)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
