### PR TITLE
mastercontainer and nextcloud: replace sudo with su-exec

### DIFF
--- a/Containers/mastercontainer/Dockerfile
+++ b/Containers/mastercontainer/Dockerfile
@@ -31,7 +31,7 @@ COPY --chmod=664 Containers/mastercontainer/supervisord.conf /supervisord.conf
 
 WORKDIR /var/www/docker-aio
 
-# hadolint ignore=SC2086,DL3047,DL3003,DL3004
+# hadolint ignore=SC2086,DL3047,DL3003
 RUN set -ex; \
     apk upgrade --no-cache -a; \
     apk add --no-cache shadow; \
@@ -43,7 +43,7 @@ RUN set -ex; \
         ca-certificates \
         bash \
         supervisor \
-        sudo \
+        su-exec \
         netcat-openbsd \
         curl \
         grep; \
@@ -87,8 +87,8 @@ RUN set -ex; \
     rm -r ./php/tests; \
     chown www-data:www-data -R /var/www/docker-aio; \
     cd php; \
-    sudo -E -u www-data composer install --no-dev; \
-    sudo -E -u www-data composer clear-cache; \
+    su-exec www-data composer install --no-dev; \
+    su-exec www-data composer clear-cache; \
     cd ..; \
     rm -f /usr/local/bin/composer; \
     chmod -R 770 /var/www/docker-aio; \

--- a/Containers/mastercontainer/cron.sh
+++ b/Containers/mastercontainer/cron.sh
@@ -51,33 +51,33 @@ while true; do
 
     # Check for updates and send notification if yes on saturdays
     if [ "$(date +%u)" = 6 ]; then
-        sudo -E -u www-data php /var/www/docker-aio/php/src/Cron/UpdateNotification.php
+        su-exec www-data php /var/www/docker-aio/php/src/Cron/UpdateNotification.php
     fi
 
     # Check if AIO is outdated
-    sudo -E -u www-data php /var/www/docker-aio/php/src/Cron/OutdatedNotification.php
+    su-exec www-data php /var/www/docker-aio/php/src/Cron/OutdatedNotification.php
 
     # Update deSEC DNS IP record (no-op when IP is unchanged or deSEC is not configured)
-    sudo -E -u www-data php /var/www/docker-aio/php/src/Cron/UpdateDesecIp.php
+    su-exec www-data php /var/www/docker-aio/php/src/Cron/UpdateDesecIp.php
 
     # Remove sessions older than 24h
     find "/mnt/docker-aio-config/session/" -mindepth 1 -mmin +1440 -delete
 
     # Remove nextcloud-aio-domaincheck container
-    if sudo -E -u www-data docker ps --format "{{.Names}}" --filter "status=exited" | grep -q "^nextcloud-aio-domaincheck$"; then
-        sudo -E -u www-data docker container remove nextcloud-aio-domaincheck
+    if su-exec www-data docker ps --format "{{.Names}}" --filter "status=exited" | grep -q "^nextcloud-aio-domaincheck$"; then
+        su-exec www-data docker container remove nextcloud-aio-domaincheck
     fi
 
     # Remove dangling images (support both deprecated label-schema and OCI standard vendor label)
-    sudo -E -u www-data docker image prune --filter "label=org.label-schema.vendor=Nextcloud" --force
-    sudo -E -u www-data docker image prune --filter "label=org.opencontainers.image.vendor=Nextcloud" --force
+    su-exec www-data docker image prune --filter "label=org.label-schema.vendor=Nextcloud" --force
+    su-exec www-data docker image prune --filter "label=org.opencontainers.image.vendor=Nextcloud" --force
 
     # Check for available free space
-    sudo -E -u www-data php /var/www/docker-aio/php/src/Cron/CheckFreeDiskSpace.php
+    su-exec www-data php /var/www/docker-aio/php/src/Cron/CheckFreeDiskSpace.php
 
     # Remove mastercontainer from default bridge network
-    if sudo -E -u www-data docker inspect nextcloud-aio-mastercontainer  --format "{{.NetworkSettings.Networks}}" | grep -q "bridge"; then
-        sudo -E -u www-data docker network disconnect bridge nextcloud-aio-mastercontainer
+    if su-exec www-data docker inspect nextcloud-aio-mastercontainer  --format "{{.NetworkSettings.Networks}}" | grep -q "bridge"; then
+        su-exec www-data docker network disconnect bridge nextcloud-aio-mastercontainer
     fi
 
     # Wait 60s so that the whole loop will not be executed again

--- a/Containers/mastercontainer/daily-backup.sh
+++ b/Containers/mastercontainer/daily-backup.sh
@@ -24,7 +24,7 @@ fi
 if [ "$LOCK_FILE_PRESENT" = 0 ] || ! [ -f "/mnt/docker-aio-config/data/daily_backup_running" ]; then
     find "/mnt/docker-aio-config/session/" -mindepth 1 -delete
 fi
-sudo -E -u www-data touch "/mnt/docker-aio-config/data/daily_backup_running"
+su-exec www-data touch "/mnt/docker-aio-config/data/daily_backup_running"
 
 # Check if apache is running/stopped, watchtower is stopped and backupcontainer is stopped
 LOCAL_APACHE_PORT="$(docker inspect nextcloud-aio-apache --format "{{.Config.Env}}" | grep -o 'APACHE_PORT=[0-9]\+' | grep -o '[0-9]\+' | head -1)"
@@ -54,7 +54,7 @@ done
 if [ "$AUTOMATIC_UPDATES" = 1 ]; then
     echo "Starting mastercontainer update..." 
     echo "(The script might get exited due to that. In order to update all the other containers correctly, you need to run this script with the same settings a second time.)"
-    sudo -E -u www-data php /var/www/docker-aio/php/src/Cron/UpdateMastercontainer.php
+    su-exec www-data php /var/www/docker-aio/php/src/Cron/UpdateMastercontainer.php
 fi
 
 # Wait for watchtower to stop
@@ -71,20 +71,20 @@ fi
 # Update container images to reduce downtime later on
 if [ "$AUTOMATIC_UPDATES" = 1 ]; then
     echo "Updating container images..."
-    sudo -E -u www-data php /var/www/docker-aio/php/src/Cron/PullContainerImages.php
+    su-exec www-data php /var/www/docker-aio/php/src/Cron/PullContainerImages.php
 fi
 
 # Stop containers if required
 # shellcheck disable=SC2235
 if [ "$CHECK_BACKUP" != 1 ] && ([ "$DAILY_BACKUP" != 1 ] || [ "$STOP_CONTAINERS" = 1 ]); then
     echo "Stopping containers..."
-    sudo -E -u www-data php /var/www/docker-aio/php/src/Cron/StopContainers.php
+    su-exec www-data php /var/www/docker-aio/php/src/Cron/StopContainers.php
 fi
 
 # Execute the backup itself and some related tasks (also stops the containers)
 if [ "$DAILY_BACKUP" = 1 ]; then
     echo "Creating daily backup..."
-    sudo -E -u www-data php /var/www/docker-aio/php/src/Cron/CreateBackup.php
+    su-exec www-data php /var/www/docker-aio/php/src/Cron/CreateBackup.php
     if ! docker ps --format "{{.Names}}" | grep -q "^nextcloud-aio-borgbackup$"; then
         echo "Something seems to be wrong: the borg container should be started at this step."
     fi
@@ -97,17 +97,17 @@ fi
 # Execute backup check
 if [ "$CHECK_BACKUP" = 1 ]; then
     echo "Starting backup check..."
-    sudo -E -u www-data php /var/www/docker-aio/php/src/Cron/CheckBackup.php
+    su-exec www-data php /var/www/docker-aio/php/src/Cron/CheckBackup.php
 fi
 
 # Start and/or update containers
 if [ "$AUTOMATIC_UPDATES" = 1 ]; then
     echo "Starting and updating containers..."
-    sudo -E -u www-data php /var/www/docker-aio/php/src/Cron/StartAndUpdateContainers.php
+    su-exec www-data php /var/www/docker-aio/php/src/Cron/StartAndUpdateContainers.php
 else
     if [ "$START_CONTAINERS" = 1 ]; then
         echo "Starting containers without updating them..."
-        sudo -E -u www-data php /var/www/docker-aio/php/src/Cron/StartContainers.php
+        su-exec www-data php /var/www/docker-aio/php/src/Cron/StartContainers.php
     fi
 fi
 
@@ -131,7 +131,7 @@ if [ "$DAILY_BACKUP" = 1 ] && ([ "$AUTOMATIC_UPDATES" = 1 ] || [ "$START_CONTAIN
         done
     fi
     echo "Sending backup notification..."
-    sudo -E -u www-data php /var/www/docker-aio/php/src/Cron/BackupNotification.php
+    su-exec www-data php /var/www/docker-aio/php/src/Cron/BackupNotification.php
 fi
 
 echo "Daily backup script has finished"

--- a/Containers/mastercontainer/start.sh
+++ b/Containers/mastercontainer/start.sh
@@ -55,7 +55,7 @@ elif mountpoint -q /var/www/docker-aio/php/containers.json; then
     echo "If you need to customize things, feel free to use https://github.com/nextcloud/all-in-one/tree/main/manual-install"
     echo "See https://github.com/nextcloud/all-in-one/blob/main/manual-install/latest.yml"
     exit 1
-elif ! sudo -E -u www-data test -r /var/run/docker.sock; then
+elif ! su-exec www-data test -r /var/run/docker.sock; then
     echo "Trying to fix docker.sock permissions internally..."
     DOCKER_GROUP=$(stat -c '%G' /var/run/docker.sock)
     DOCKER_GROUP_ID=$(stat -c '%g' /var/run/docker.sock)
@@ -73,7 +73,7 @@ elif ! sudo -E -u www-data test -r /var/run/docker.sock; then
         groupadd -g "$DOCKER_GROUP_ID" docker
         usermod -aG docker www-data
     fi
-    if ! sudo -E -u www-data test -r /var/run/docker.sock; then
+    if ! su-exec www-data test -r /var/run/docker.sock; then
         print_red "Docker socket is not readable by the www-data user. Cannot continue."
         exit 1
     fi
@@ -108,8 +108,8 @@ fi
 FALLBACK_DOCKER_API_VERSION="1.41"
 
 # Check if docker info can be used
-if ! sudo -E -u www-data docker info &>/dev/null; then
-    if ! sudo -E -u www-data DOCKER_API_VERSION="$FALLBACK_DOCKER_API_VERSION" docker info &>/dev/null; then
+if ! su-exec www-data docker info &>/dev/null; then
+    if ! su-exec www-data env DOCKER_API_VERSION="$FALLBACK_DOCKER_API_VERSION" docker info &>/dev/null; then
         print_red "Cannot connect to the docker socket. Cannot proceed."
         echo "Did you maybe remove group read permissions for the docker socket? AIO needs them in order to access the docker socket."
         echo "If SELinux is enabled on your host, see https://github.com/nextcloud/all-in-one#are-there-known-problems-when-selinux-is-enabled"
@@ -125,9 +125,9 @@ fi
 # Docker api version check
 # shellcheck disable=SC2001
 API_VERSION_NUMB="$(echo "$DOCKER_API_VERSION" | sed 's/\.//')"
-LOCAL_API_VERSION_NUMB="$(sudo -E -u www-data docker version | grep -i "api version" | grep -oP '[0-9]+.[0-9]+' | head -1 | sed 's/\.//')"
+LOCAL_API_VERSION_NUMB="$(su-exec www-data docker version | grep -i "api version" | grep -oP '[0-9]+.[0-9]+' | head -1 | sed 's/\.//')"
 if [ -z "$LOCAL_API_VERSION_NUMB" ]; then
-    LOCAL_API_VERSION_NUMB="$(sudo -E -u www-data DOCKER_API_VERSION="$FALLBACK_DOCKER_API_VERSION" docker version | grep -i "api version" | grep -oP '[0-9]+.[0-9]+' | head -1 | sed 's/\.//')"
+    LOCAL_API_VERSION_NUMB="$(su-exec www-data env DOCKER_API_VERSION="$FALLBACK_DOCKER_API_VERSION" docker version | grep -i "api version" | grep -oP '[0-9]+.[0-9]+' | head -1 | sed 's/\.//')"
 fi
 if [ -n "$LOCAL_API_VERSION_NUMB" ] && [ -n "$API_VERSION_NUMB" ]; then
     if ! [ "$LOCAL_API_VERSION_NUMB" -ge "$API_VERSION_NUMB" ]; then
@@ -143,7 +143,7 @@ else
 fi
 
 # Check Storage drivers
-STORAGE_DRIVER="$(sudo -E -u www-data docker info | grep "Storage Driver")"
+STORAGE_DRIVER="$(su-exec www-data docker info | grep "Storage Driver")"
 # Check if vfs is used: https://github.com/nextcloud/all-in-one/discussions/1467
 if echo "$STORAGE_DRIVER" | grep -q vfs; then
     echo "$STORAGE_DRIVER"
@@ -154,26 +154,26 @@ elif echo "$STORAGE_DRIVER" | grep -q fuse-overlayfs; then
 fi
 
 # Check if snap install
-if sudo -E -u www-data docker info | grep "Docker Root Dir" | grep "/var/snap/docker/"; then
+if su-exec www-data docker info | grep "Docker Root Dir" | grep "/var/snap/docker/"; then
     print_red "Warning: It looks like your installation uses docker installed via snap."
     print_red "This comes with some limitations and is disrecommended by the docker maintainers."
     print_red "See for example https://github.com/nextcloud/all-in-one/discussions/4890#discussioncomment-10386752"
 fi
 
 # Check if startup command was executed correctly
-if ! sudo -E -u www-data docker ps --format "{{.Names}}" | grep -q "^nextcloud-aio-mastercontainer$"; then
+if ! su-exec www-data docker ps --format "{{.Names}}" | grep -q "^nextcloud-aio-mastercontainer$"; then
     print_red "It seems like you did not give the mastercontainer the correct name? (The 'nextcloud-aio-mastercontainer' container was not found.)
 Using a different name is not supported since mastercontainer updates will not work in that case!
 If you are on docker swarm and try to run AIO, see https://github.com/nextcloud/all-in-one#can-i-run-this-with-docker-swarm"
     exit 1
-elif sudo -E -u www-data docker inspect nextcloud-aio-mastercontainer --format "{{.Config.Image}}" | grep -q '@'; then
+elif su-exec www-data docker inspect nextcloud-aio-mastercontainer --format "{{.Config.Image}}" | grep -q '@'; then
     print_red "It seems like you used a hash for the mastercontainer image tag. This is not supported!"
     exit 1
-elif ! sudo -E -u www-data docker volume ls --format "{{.Name}}" | grep -q "^nextcloud_aio_mastercontainer$"; then
+elif ! su-exec www-data docker volume ls --format "{{.Name}}" | grep -q "^nextcloud_aio_mastercontainer$"; then
     print_red "It seems like you did not give the mastercontainer volume the correct name? (The 'nextcloud_aio_mastercontainer' volume was not found.)
 Using a different name is not supported since the built-in backup solution will not work in that case!"
     exit 1
-elif ! sudo -E -u www-data docker inspect nextcloud-aio-mastercontainer --format '{{.Mounts}}' | grep -q " nextcloud_aio_mastercontainer "; then
+elif ! su-exec www-data docker inspect nextcloud-aio-mastercontainer --format '{{.Mounts}}' | grep -q " nextcloud_aio_mastercontainer "; then
     print_red "It seems like you did not attach the 'nextcloud_aio_mastercontainer' volume to the mastercontainer?
 This is not supported since the built-in backup solution will not work in that case!"
     exit 1

--- a/Containers/nextcloud/Dockerfile
+++ b/Containers/nextcloud/Dockerfile
@@ -234,7 +234,7 @@ RUN set -ex; \
         git \
         postgresql-client \
         tzdata \
-        sudo \
+        su-exec \
         grep \
         nodejs \
         bind-tools \

--- a/Containers/nextcloud/notify-all.sh
+++ b/Containers/nextcloud/notify-all.sh
@@ -5,7 +5,7 @@ if [ "$AIO_LOG_LEVEL" = 'debug' ]; then
 fi
 
 if [[ "$EUID" = 0 ]]; then
-    COMMAND=(sudo -E -u www-data php /var/www/html/occ)
+    COMMAND=(su-exec www-data php /var/www/html/occ)
 else
     COMMAND=(php /var/www/html/occ)
 fi

--- a/Containers/nextcloud/notify.sh
+++ b/Containers/nextcloud/notify.sh
@@ -5,7 +5,7 @@ if [ "$AIO_LOG_LEVEL" = 'debug' ]; then
 fi
 
 if [[ "$EUID" = 0 ]]; then
-    COMMAND=(sudo -E -u www-data php /var/www/html/occ)
+    COMMAND=(su-exec www-data php /var/www/html/occ)
 else
     COMMAND=(php /var/www/html/occ)
 fi

--- a/Containers/nextcloud/root.motd
+++ b/Containers/nextcloud/root.motd
@@ -1,4 +1,4 @@
 Warning: You have logged in into the Nextcloud container as root user.
 See https://github.com/nextcloud/all-in-one#how-to-run-occ-commands if you want to run occ commands.
-Apart from that, you can use 'sudo -E -u www-data php occ <your-command>' in order to run occ commands.
+Apart from that, you can use 'su-exec www-data php occ <your-command>' in order to run occ commands.
 Of course <your-command> needs to be substituted with the command that you want to use.

--- a/Containers/nextcloud/start.sh
+++ b/Containers/nextcloud/start.sh
@@ -12,7 +12,7 @@ fi
 # Only start container if database is accessible
 # POSTGRES_HOST must be set in the containers env vars and POSTGRES_PORT has a default above
 # shellcheck disable=SC2153
-while ! sudo -E -u www-data nc -z "$POSTGRES_HOST" "$POSTGRES_PORT"; do
+while ! su-exec www-data nc -z "$POSTGRES_HOST" "$POSTGRES_PORT"; do
     echo "Waiting for database to start..."
     sleep 5
 done
@@ -29,7 +29,7 @@ fi
 # Fix false database connection on old instances
 if [ -f "/var/www/html/config/config.php" ]; then
     sleep 2
-    while ! sudo -E -u www-data env PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "select now()"; do
+    while ! su-exec www-data env PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "select now()"; do
         echo "Waiting for the database to start..."
         sleep 5
     done
@@ -62,12 +62,12 @@ if [ "$AIO_LOG_LEVEL" != 'debug' ]; then
 fi
 
 # Check datadir permissions
-sudo -E -u www-data touch "$NEXTCLOUD_DATA_DIR/this-is-a-test-file" &>/dev/null
+su-exec www-data touch "$NEXTCLOUD_DATA_DIR/this-is-a-test-file" &>/dev/null
 if ! [ -f "$NEXTCLOUD_DATA_DIR/this-is-a-test-file" ]; then
     chown -R www-data:root "$NEXTCLOUD_DATA_DIR"
     chmod 750 -R "$NEXTCLOUD_DATA_DIR"
 fi
-sudo -E -u www-data rm -f "$NEXTCLOUD_DATA_DIR/this-is-a-test-file"
+su-exec www-data rm -f "$NEXTCLOUD_DATA_DIR/this-is-a-test-file"
 
 # Install additional dependencies
 if [ -n "$ADDITIONAL_APKS" ]; then
@@ -153,7 +153,7 @@ if [ -n "$ADDITIONAL_PHP_EXTENSIONS" ]; then
 fi
 
 # Run original entrypoint
-if ! sudo -E -u www-data bash /entrypoint.sh; then
+if ! su-exec www-data bash /entrypoint.sh; then
     exit 1
 fi
 

--- a/Containers/nextcloud/upgrade-latest-major.sh
+++ b/Containers/nextcloud/upgrade-latest-major.sh
@@ -2,7 +2,7 @@
 
 PHP_CLI="php"
 if [[ "$EUID" = 0 ]]; then
-    PHP_CLI="sudo -u www-data -E $PHP_CLI"
+    PHP_CLI="su-exec www-data $PHP_CLI"
 fi
 
 # shellcheck disable=SC2016


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud AIO instances and users in the meantime.
-->

- Replaces sudo with su-exec, see https://github.com/ncopa/su-exec

## Summary
- [x] The PR was tested and verified that it works locally
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests (playwright if possible) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation has been updated or is not required
- [x] [Labels added](https://github.com/nextcloud/all-in-one/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone next added](https://github.com/nextcloud/all-in-one/milestones)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
