### PR TITLE
scrutiny: fix access to nvme drives

### DIFF
--- a/php/src/Docker/DockerActionManager.php
+++ b/php/src/Docker/DockerActionManager.php
@@ -480,8 +480,11 @@ readonly class DockerActionManager {
             }
         // Special things for the scrutiny container which should not be exposed in the containers.json
         } elseif ($container->identifier === 'nextcloud-aio-scrutiny') {
-            // Allow it to access block devices
-            $requestBody['HostConfig']['DeviceCgroupRules'] = ["b *:* rmw"];
+            // Allow it to access block devices (e.g. /dev/sda for SATA drives) and
+            // character devices (needed for NVMe drives: smartctl reads their SMART data
+            // via admin passthrough ioctls on the NVMe controller character device
+            // /dev/nvme0 and not via the block device /dev/nvme0n1)
+            $requestBody['HostConfig']['DeviceCgroupRules'] = ["b *:* rmw", "c *:* rmw"];
         // Special things for the makemkv container which should not be exposed in the containers.json
         } elseif ($container->identifier === 'nextcloud-aio-makemkv') {
             // Allow it to access block devices


### PR DESCRIPTION
- Fix https://github.com/szaimen/aio-scrutiny/issues/44

## Summary
- [ ] The PR was tested and verified that it works locally
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests (playwright if possible) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation has been updated or is not required
- [x] [Labels added](https://github.com/nextcloud/all-in-one/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone next added](https://github.com/nextcloud/all-in-one/milestones)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
