### PR TITLE
mastercontainer: block the docker network gateway on the login endpoints

### DIFF
--- a/Containers/mastercontainer/acme.Caddyfile
+++ b/Containers/mastercontainer/acme.Caddyfile
@@ -36,11 +36,21 @@ https://:8443 {
     import headers.Caddyfile
     header Strict-Transport-Security max-age=31536000;
 
-	@denied {
+	@denied-host {
 		path /api/auth/login /api/auth/getlogin
 		remote_host nextcloud-aio-nextcloud
 	}
-	abort @denied
+	abort @denied-host
+
+	# The gateway ip of the nextcloud-aio network is used as source address by containers
+	# that reach the mastercontainer via the host, so it needs to be blocked as well.
+	# The variable gets set in start.sh and falls back to localhost if the network
+	# does not exist yet. In that case it gets applied on the next container restart.
+	@denied-gateway {
+		path /api/auth/login /api/auth/getlogin
+		remote_ip {$DOCKER_NETWORK_GATEWAY}
+	}
+	abort @denied-gateway
 
 	root * /var/www/docker-aio/php/public
 	php_fastcgi unix//run/php.sock

--- a/Containers/mastercontainer/internal.Caddyfile
+++ b/Containers/mastercontainer/internal.Caddyfile
@@ -26,11 +26,21 @@
 https://:8080 {
     import headers.Caddyfile
 
-	@denied {
+	@denied-host {
 		path /api/auth/login /api/auth/getlogin
 		remote_host nextcloud-aio-nextcloud
 	}
-	abort @denied
+	abort @denied-host
+
+	# The gateway ip of the nextcloud-aio network is used as source address by containers
+	# that reach the mastercontainer via the host, so it needs to be blocked as well.
+	# The variable gets set in start.sh and falls back to localhost if the network
+	# does not exist yet. In that case it gets applied on the next container restart.
+	@denied-gateway {
+		path /api/auth/login /api/auth/getlogin
+		remote_ip {$DOCKER_NETWORK_GATEWAY}
+	}
+	abort @denied-gateway
 
 	root * /var/www/docker-aio/php/public
 	php_fastcgi unix//run/php.sock

--- a/Containers/mastercontainer/start.sh
+++ b/Containers/mastercontainer/start.sh
@@ -436,6 +436,20 @@ if [ -d "/mnt/docker-aio-config/caddy/locks" ]; then
     rm -rf /mnt/docker-aio-config/caddy/locks/*
 fi
 
+# Get the gateway ip of the nextcloud-aio network which is used by the Caddyfiles.
+# Containers that reach the mastercontainer via the host use it as source address,
+# so it needs to be blocked in addition to the nextcloud container itself.
+# A network can have multiple gateways (e.g. one for IPv4 and one for IPv6), so get them all.
+# remote_ip accepts multiple space separated values.
+DOCKER_NETWORK_GATEWAY="$(su-exec www-data docker network inspect nextcloud-aio --format '{{range .IPAM.Config}}{{if .Gateway}}{{.Gateway}} {{end}}{{end}}' 2>/dev/null | sed 's| *$||')"
+if [ -z "$DOCKER_NETWORK_GATEWAY" ]; then
+    # The network gets created by the php code when the containers get started for the first time,
+    # so it might not exist yet. Fall back to localhost which is a no-op for the matcher and
+    # apply the actual gateway ip on the next container restart.
+    DOCKER_NETWORK_GATEWAY="127.0.0.1"
+fi
+export DOCKER_NETWORK_GATEWAY
+
 # Fix the Caddyfile format
 caddy fmt --overwrite /acme.Caddyfile
 caddy fmt --overwrite /internal.Caddyfile


### PR DESCRIPTION
The `/api/auth/login` and `/api/auth/getlogin` endpoints are already blocked for the nextcloud container via the `remote_host` matcher. However containers that reach the mastercontainer via the host use the gateway ip of the `nextcloud-aio` network as source address, so requests coming from them were not caught by the existing matcher.

This reads the gateway ip in `start.sh`, exports it as `DOCKER_NETWORK_GATEWAY` and blocks it via `remote_ip` in both `acme.Caddyfile` and `internal.Caddyfile`.

### Implementation notes

- **Why a second matcher block** instead of just adding a `remote_ip` line to the existing `@denied`: matchers of different types inside one named matcher are AND'ed together ("Matchers in a set are AND'ed together; i.e. all must match"), so `path` + `remote_host` + `remote_ip` in a single block would never match — a client cannot be both the nextcloud container and the gateway. Two blocks with two `abort`s give the intended `path AND (remote_host OR remote_ip)`. The existing matcher was renamed `@denied` -> `@denied-host` for symmetry.
- **Why `remote_ip` and not `remote_host`**: the `caddy-remote-host` plugin only resolves host names via DNS, so the built-in `remote_ip` matcher is used for the ip. It accepts multiple space separated values, so all gateways of the network (e.g. IPv4 + IPv6) are passed at once.
- **The `{{if .Gateway}}` guard** in the `docker network inspect` format string is needed because `Gateway` is declared `omitzero` in moby's `IPAMConfig`, so a subnet without a gateway would otherwise produce a stray empty entry.
- **Fallback**: the `nextcloud-aio` network only gets created by the php code once the containers get started for the first time, so it may not exist on a fresh install. In that case the value falls back to `127.0.0.1`, which is a no-op for the matcher, and the actual gateway ip gets applied on the next restart of the mastercontainer. The network is deliberately not created in `start.sh`.

The `127.0.0.1` fallback is inert in practice: both paths are only ever requested by browsers, nothing internal calls them over loopback.

## Summary
- [ ] The PR was tested and verified that it works locally <!-- see the testing note below -->
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests (playwright if possible) are included
- [ ] Screenshots before/after for front-end changes <!-- n/a, no front-end changes -->
- [x] Documentation has been updated or is not required
- [x] [Labels added](https://github.com/nextcloud/all-in-one/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone next added](https://github.com/nextcloud/all-in-one/milestones)

> [!IMPORTANT]
> **Not yet verified at runtime.** The matcher semantics and `remote_ip` syntax were confirmed against the Caddy docs, and the rendered config was checked by substitution, but `caddy validate` and a live request test were not run — no Docker daemon or local caddy binary was available. Worth confirming in a real container before merging, in particular that `{$DOCKER_NETWORK_GATEWAY}` is picked up by the caddy processes spawned via supervisord.

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
