### PR TITLE
aio-stalwart: change maintainer

### DIFF
--- a/community-containers/stalwart/readme.md
+++ b/community-containers/stalwart/readme.md
@@ -1,22 +1,24 @@
 > [!CAUTION]
-> Be aware that the mail server is the most difficult service to deploy.
-> 
+> Be aware that the mail server is the most challenging service to deploy.
+>
 > Do not use this feature as a main mail server or without a redundancy system and without knowledge.
 
 ## Stalwart mail server
-This container bundles the [Stalwart](https://stalw.art/) mail server and auto-configures it for you.
+This container bundles the [Stalwart](https://stalw.art/) mail server and autoconfigures it for you.
 
 ### Notes
 Documentation is available on the container repository.
 This documentation is regularly updated and is intended to be as simple and detailed as possible.
 Thanks for all your feedback!
 
-- See https://github.com/docjyJ/aio-stalwart#getting-started for getting start with this container.
+- See https://github.com/winterrific/aio-stalwart#getting-started for getting start with this container.
 - See https://stalw.art/docs/faq for further faq and docs on the project
 - See https://github.com/nextcloud/all-in-one/tree/main/community-containers#community-containers how to add it to the AIO stack
 
 ### Repository
-https://github.com/docjyj/aio-stalwart
+https://github.com/winterrific/aio-stalwart
 
 ### Maintainer
-https://github.com/docjyj
+https://github.com/winterrific
+
+Created by https://github.com/docjyj

--- a/community-containers/stalwart/stalwart.json
+++ b/community-containers/stalwart/stalwart.json
@@ -5,7 +5,7 @@
             "display_name": "Stalwart",
             "documentation": "https://github.com/nextcloud/all-in-one/tree/main/community-containers/stalwart",
             "image": "ghcr.io/winterrific/aio-stalwart",
-            "image_tag": "v3",
+            "image_tag": "v0",
             "internal_port": "10003",
             "restart": "unless-stopped",
             "ports": [

--- a/community-containers/stalwart/stalwart.json
+++ b/community-containers/stalwart/stalwart.json
@@ -4,7 +4,7 @@
             "container_name": "nextcloud-aio-stalwart",
             "display_name": "Stalwart",
             "documentation": "https://github.com/nextcloud/all-in-one/tree/main/community-containers/stalwart",
-            "image": "ghcr.io/docjyj/aio-stalwart",
+            "image": "ghcr.io/winterrific/aio-stalwart",
             "image_tag": "v3",
             "internal_port": "10003",
             "restart": "unless-stopped",


### PR DESCRIPTION
As discussed with @docjyJ in https://github.com/docjyJ/aio-stalwart/pull/123, I'll take over the maintenance of the `aio-stalwart` community container. 
Where I want to bring out a big THANK YOU to @docjyJ to set up this container and all the efforts you put into it. 

This PR changes the container image from docjyJ to winterrific and the references in the documentation. Currently, there are no improvements done in the container itself. However, the next two releases are planned, where the
1st introduces an export script to save and convert the v0.15 settings, which then will get imported in the
2nd including the upgrade to v0.16 of stalwart. 

**v0.16 has a BREAKING change in how stalwart is configured and managed**. So far, Stalwart configuration is stored in a TOML file. In v0.16 all settings are stored in the database and the TOML file is gone. Thus, the settings have to be exported first and then imported in the to v0.16 upgraded container image. 

## Summary
- [x] The PR was tested and verified that it works locally
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests (playwright if possible) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation has been updated or is not required
- [x] [Labels added](https://github.com/nextcloud/all-in-one/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone next added](https://github.com/nextcloud/all-in-one/milestones)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
