### PR TITLE
precompress static files

### DIFF
--- a/Containers/apache/nextcloud.conf
+++ b/Containers/apache/nextcloud.conf
@@ -17,6 +17,28 @@ Listen 8000
     <Proxy "fcgi://${NEXTCLOUD_HOST}:9000" flushpackets=on>
     </Proxy>
 
+    <IfModule mod_rewrite.c>
+        RewriteEngine On
+        RewriteCond %{HTTP:Accept-Encoding} br
+        RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI}.br -s
+        RewriteRule ^ %{REQUEST_URI}.br [END]
+    </IfModule>
+
+    <IfModule mod_mime.c>
+        AddEncoding br .br
+    </IfModule>
+
+    <IfModule mod_headers.c>
+        <FilesMatch "\.(css|js|mjs|svg|ico)\.br$">
+            <If "%{QUERY_STRING} =~ /(^|&)v=/">
+                Header set Cache-Control "max-age=15778463, immutable"
+            </If>
+            <Else>
+                Header set Cache-Control "max-age=15778463"
+            </Else>
+        </FilesMatch>
+    </IfModule>
+
     # Nextcloud dir
     DocumentRoot /var/www/html/
     <Directory /var/www/html/>

--- a/Containers/nextcloud/Dockerfile
+++ b/Containers/nextcloud/Dockerfile
@@ -228,6 +228,7 @@ RUN set -ex; \
     \
     apk add --no-cache \
         bash \
+        brotli \
         netcat-openbsd \
         openssl \
         gnupg \
@@ -268,6 +269,8 @@ RUN set -ex; \
     sed -i 's|access.log = /proc/self/fd/2|access.log = /proc/self/fd/1|' /usr/local/etc/php-fpm.d/docker.conf; \
     \
     echo "[ -n \"\$TERM\" ] && [ -f /root.motd ] && cat /root.motd" >> /root/.bashrc; \
+    \
+    find /usr/src/nextcloud/apps /usr/src/nextcloud/core /usr/src/nextcloud/dist \( -name "*.js" -o -name "*.mjs" -o -name "*.css" -o -name "*.html" -o -name "*.svg" -o -name "*.ico" \) -type f -print0 | xargs -r0 -P "$(nproc)" -n 1 brotli -q 11; \
     \
     chown www-data:root -R /usr/src && \
     chmod 777 -R /usr/local/etc/php/conf.d && \

--- a/Containers/nextcloud/entrypoint.sh
+++ b/Containers/nextcloud/entrypoint.sh
@@ -223,6 +223,7 @@ if ! [ -f "$NEXTCLOUD_DATA_DIR/skip.update" ]; then
             mv /usr/src/tmp/nextcloud "$SOURCE_LOCATION"
             rm -r /usr/src/tmp
             rm -r /usr/src/temp-nextcloud
+            find "$SOURCE_LOCATION/apps" "$SOURCE_LOCATION/core" "$SOURCE_LOCATION/dist" \( -name "*.js" -o -name "*.mjs" -o -name "*.css" -o -name "*.html" -o -name "*.svg" -o -name "*.ico" \) -type f -print0 | xargs -r0 -P "$(nproc)" -n 1 brotli -q 11;
             # shellcheck disable=SC2016
             image_version="$(php -r "require '$SOURCE_LOCATION/version.php'; echo implode('.', \$OC_Version);")"
             IMAGE_MAJOR="${image_version%%.*}"

--- a/Containers/nextcloud/upgrade-latest-major.sh
+++ b/Containers/nextcloud/upgrade-latest-major.sh
@@ -36,6 +36,7 @@ if ! $PHP_CLI -r "version_compare(getenv('INSTALLED_MAJOR'), getenv('IMAGE_MAJOR
         exit 1
     fi
 fi
+find /var/www/html/apps /var/www/html/core /var/www/html/dist \( -name "*.js" -o -name "*.mjs" -o -name "*.css" -o -name "*.html" -o -name "*.svg" -o -name "*.ico" \) -type f -print0 | xargs -r0 -P "$(nproc)" -n 1 brotli -q 11;
 $PHP_CLI /var/www/html/occ config:system:set updatechecker --type=bool --value=true
 $PHP_CLI /var/www/html/occ app:enable nextcloud-aio --force
 $PHP_CLI /var/www/html/occ db:add-missing-columns


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud AIO instances and users in the meantime.
-->

- Resolves: https://github.com/nextcloud/all-in-one/pull/8521#issuecomment-5189898081

## Summary
- [ ] The PR was tested and verified that it works locally
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests (playwright if possible) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation has been updated or is not required
- [ ] [Labels added](https://github.com/nextcloud/all-in-one/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone next added](https://github.com/nextcloud/all-in-one/milestones)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

After making some size comparisons, the results speak for brotli, it is the smallest when compressing nextcloud and the support in browser is perfect since many many years. So zstd (a little bit bigger on the highest level compared to brotlis highest level and not supported in older browsers) and gzip (bad compression) are not needed.

But I must correct myself in one important point: integrity checks break...
I see two options how this could be fixed:
1. compressed files are saved in a diffrent folder and apache rewrites to this folder if brotli is used, works fine, but skips the check for all precompressed files so they could be modified without the check noticing it
2. resign all files again after compressing them with a selfsigned key

I think option 2 is the best