### PR TITLE
nextcloud: fix taskprocessing-worker is not restarted after its timeout

### DIFF
--- a/Containers/nextcloud/supervisord.conf
+++ b/Containers/nextcloud/supervisord.conf
@@ -31,6 +31,7 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 command=php /var/www/html/occ taskprocessing:worker --timeout 300
+autorestart=true
 user=www-data
 
 [program:run-exec-commands]


### PR DESCRIPTION
- Resolves issues reported in:  https://github.com/nextcloud/all-in-one/discussions/5430

When `taskprocessing:worker` reaches its timeout, it exits with code 0. Since no `autorestart` or `exitcodes` directives are specified in the Supervisor configuration for this program, the default values are used (`unexpected` and `0`, respectively).

This causes exit code 0 to be treated as an expected exit, so Supervisor does not restart the process, since it only restarts the program after an unexpected exit.

By adding `autorestart=true` to the program's Supervisor configuration, the process will be restarted regardless of its exit code, unless it's still in the `STARTING` state, which lasts only one second. `taskprocessing:worker`, however, normally runs for 300 seconds before exiting.

## Summary
- [x] The PR was tested and verified that it works locally
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests (playwright if possible) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation has been updated or is not required
- [x] [Labels added](https://github.com/nextcloud/all-in-one/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone next added](https://github.com/nextcloud/all-in-one/milestones)

