### PR TITLE
nextcloud: fix ftps support disabled due to missing openssl-dev at ftp configur…

### DIFF
--- a/Containers/nextcloud/Dockerfile
+++ b/Containers/nextcloud/Dockerfile
@@ -60,6 +60,7 @@ RUN set -ex; \
         libxml2-dev \
         libzip-dev \
         openldap-dev \
+        openssl-dev \
         pcre-dev \
         postgresql-dev \
     ; \
@@ -70,6 +71,7 @@ RUN set -ex; \
     docker-php-ext-install -j "$(nproc)" \
         bcmath \
         exif \
+        ftp \
         gd \
         gmp \
         intl \
@@ -205,7 +207,6 @@ RUN set -ex; \
         bz2 \
         imap \
         pgsql \
-        ftp \
     ; \
     pecl install smbclient; \
     docker-php-ext-enable smbclient; \


### PR DESCRIPTION
FTPS mounts fail with `SSL/TLS required on the control channel` even though
the Dockerfile already passes `--with-openssl-dir=/usr` to
`docker-php-ext-configure ftp`. Root cause: `openssl-dev` was not installed
yet when that configure call ran, so PHP's `ftp` extension silently built
without SSL support (`ftp_ssl_connect()` undefined at runtime).

On top of that, `ftp` was being built a **second** time later in the same
`RUN` (in the imap/samba block), without re-passing the openssl flag — this
second build overwrote the first, correctly-configured one.

### Fix
- Added `openssl-dev` to the first `.build-deps` block (where `ftp` is
  configured with `--with-openssl-dir=/usr`)
- Moved `ftp` into the first `docker-php-ext-install` call, right after its
  `docker-php-ext-configure` call
- Removed the duplicate `ftp` install from the second block

### Verification
Before:
```
FTP support => enabled
FTPS support => disabled
```
After:
```
FTP support => enabled
FTPS support => enabled
```

Thanks in advance for reviewing this, happy to adjust based on feedback.