### PR TITLE
localAI: Fix healthcheck pointing to wrong port (8080 instead of 10078)

### DIFF
--- a/community-containers/local-ai/local-ai.json
+++ b/community-containers/local-ai/local-ai.json
@@ -14,7 +14,8 @@
                 "LOCALAI_ADDRESS=:10078",
                 "LOCALAI_CONFIG_DIR=/configuration",
                 "LOCALAI_MODEL_PATH=/models",
-                "LOCALAI_BACKEND_PATH=/backends"
+                "LOCALAI_BACKEND_PATH=/backends",
+                "HEALTHCHECK_ENDPOINT=http://localhost:10078/readyz"
             ],
             "ports": [
                 {

--- a/community-containers/local-ai/local-ai.json
+++ b/community-containers/local-ai/local-ai.json
@@ -15,7 +15,7 @@
                 "LOCALAI_CONFIG_DIR=/configuration",
                 "LOCALAI_MODEL_PATH=/models",
                 "LOCALAI_BACKEND_PATH=/backends",
-                "HEALTHCHECK_ENDPOINT=http://localhost:10078/readyz"
+                "HEALTHCHECK_ENDPOINT=http://127.0.0.1:10078/readyz"
             ],
             "ports": [
                 {


### PR DESCRIPTION
Fix healthcheck pointing to wrong port (8080 instead of 10078)'

Problem: The nextcloud-aio-local-ai container is permanently reported as unhealthy, even though the LocalAI service itself works correctly.

Root cause: The base image's built-in HEALTHCHECK reads its target from the HEALTHCHECK_ENDPOINT environment variable, which defaults to http://localhost:8080/readyz. This community container configures LocalAI to listen on port 10078 instead (via LOCALAI_ADDRESS=:10078), but never overrides HEALTHCHECK_ENDPOINT to match — so the healthcheck always probes an empty port and fails.

Fix: Add HEALTHCHECK_ENDPOINT=http://localhost:10078/readyz to the environment array in local-ai.json.

Tested: Manually recreated the container on my own AIO instance with this environment variable added; it now reports healthy, and Context Chat / Nextcloud Assistant continued working normally throughout.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud AIO instances and users in the meantime.
-->

## Summary
- [x] The PR was tested and verified that it works locally
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests (playwright if possible) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation has been updated or is not required - ("not required")
- [x] [Labels added](https://github.com/nextcloud/all-in-one/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone next added](https://github.com/nextcloud/all-in-one/milestones)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI


