### PR TITLE
ci: include versions and links in dependency update release notes

### DIFF
--- a/.github/workflows/nextcloud-update.yml
+++ b/.github/workflows/nextcloud-update.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Run nextcloud-update script
+      id: nextcloud_update
       run: |
         # Inspired by https://github.com/nextcloud/docker/blob/master/update.sh
 
@@ -77,6 +78,7 @@ jobs:
         if [ -n "$NCVERSION" ]; then
           sed -i "s|^ENV NEXTCLOUD_VERSION.*|ENV NEXTCLOUD_VERSION=$NCVERSION|" ./Containers/nextcloud/Dockerfile
         fi
+        echo "nc_version=$NCVERSION" >> "$GITHUB_OUTPUT"
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v7
@@ -84,8 +86,11 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: nextcloud-update automated change
         signoff: true
-        title: Nextcloud dependency update
-        body: Automated Nextcloud container update
+        title: Nextcloud dependency update to ${{ steps.nextcloud_update.outputs.nc_version }}
+        body: |
+          Automated Nextcloud container update to version ${{ steps.nextcloud_update.outputs.nc_version }}.
+
+          See the [Nextcloud Server ${{ steps.nextcloud_update.outputs.nc_version }} release notes](https://github.com/nextcloud/server/releases/tag/v${{ steps.nextcloud_update.outputs.nc_version }}) for details.
         labels: dependencies, 3. to review
         milestone: next
         branch: nextcloud-container-update

--- a/.github/workflows/update-helm.yml
+++ b/.github/workflows/update-helm.yml
@@ -29,7 +29,7 @@ jobs:
           signoff: true
           title: Helm Chart updates
           body: Automated Helm Chart updates for the yaml files. It can be merged if it looks good at any time which will automatically trigger a new release of the helm chart.
-          labels: dependencies, 3. to review
+          labels: 3. to review
           milestone: next
           branch: aio-helm-update
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/watchtower-update.yml
+++ b/.github/workflows/watchtower-update.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Run watchtower-container-update
+      id: watchtower_update
       run: |
         # Watchtower
         watchtower_version="$(
@@ -24,15 +25,19 @@ jobs:
         watchtower_commit_hash="$(git ls-remote https://github.com/nicholas-fedor/watchtower $watchtower_version | sed 's/refs.*//')"
         sed -i "s|^ENV WATCHTOWER_COMMIT_HASH.*$|ENV WATCHTOWER_COMMIT_HASH=$watchtower_commit_hash|" ./Containers/watchtower/Dockerfile
         sed -i "s|\$WATCHTOWER_COMMIT_HASH.*$|\$WATCHTOWER_COMMIT_HASH # $watchtower_version|" ./Containers/watchtower/Dockerfile
-        
+        echo "watchtower_version=$watchtower_version" >> "$GITHUB_OUTPUT"
+
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v7
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: watchtower-update automated change
         signoff: true
-        title: watchtower container update
-        body: Automated watchtower container update
+        title: watchtower container update to ${{ steps.watchtower_update.outputs.watchtower_version }}
+        body: |
+          Automated watchtower container update to version ${{ steps.watchtower_update.outputs.watchtower_version }}.
+
+          See the [Watchtower ${{ steps.watchtower_update.outputs.watchtower_version }} release notes](https://github.com/nicholas-fedor/watchtower/releases/tag/${{ steps.watchtower_update.outputs.watchtower_version }}) for details.
         labels: dependencies, 3. to review
         milestone: next
         branch: watchtower-container-update


### PR DESCRIPTION
## Summary
- Nextcloud and Watchtower auto-update PRs now include the new version and a link to upstream release notes.
- Improves the auto-generated \"Updated Dependencies\" section called out in #8538.

Fixes #8538

## Test plan
- [ ] Trigger or dry-run the Nextcloud dependency update workflow and confirm PR title/body include version + release-notes link
- [ ] Same for the Watchtower update workflow
- [ ] Confirm release notes categorization still looks sensible
