### PR TITLE
upgrade-latest-major.sh: make sure the update-channel is set to "stable"

### DIFF
--- a/Containers/nextcloud/upgrade-latest-major.sh
+++ b/Containers/nextcloud/upgrade-latest-major.sh
@@ -17,7 +17,14 @@ if [ -n "${INSTALLED_AT}" ]; then
     INSTALLED_AT="$(echo "${INSTALLED_AT}" | sed "s|[0-9][0-9]$|00|")"
     $PHP_CLI /var/www/html/occ config:app:set core installedat --value="${INSTALLED_AT}"
 fi
+
+# Make sure updater channel is set to "stable"
+$PHP_CLI /var/www/html/occ config:system:set update_channel --value="stable"
+
+# Run the update
 $PHP_CLI /var/www/html/updater/updater.phar --no-interaction --no-backup
+
+# Do some tests
 if ! $PHP_CLI /var/www/html/occ -V || $PHP_CLI /var/www/html/occ status | grep maintenance | grep -q 'true'; then
     echo "Installation of Nextcloud failed!"
     touch "$NEXTCLOUD_DATA_DIR/install.failed"


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud AIO instances and users in the meantime.
-->

- Closes https://github.com/nextcloud/all-in-one/discussions/8587

## Summary
- [ ] The PR was tested and verified that it works locally
- [x] Or will be tested after merge on a dedicated test instance (available for maintainers)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests (playwright if possible) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation has been updated or is not required
- [x] [Labels added](https://github.com/nextcloud/all-in-one/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone next added](https://github.com/nextcloud/all-in-one/milestones)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
