### PR TITLE
Fix hadolint complaints

### DIFF
--- a/Containers/apache/Dockerfile
+++ b/Containers/apache/Dockerfile
@@ -102,7 +102,7 @@ CMD ["/usr/bin/supervisord", "-c", "/supervisord.conf"]
 
 ENV AIO_LOG_LEVEL=warn
 
-HEALTHCHECK CMD /healthcheck.sh
+HEALTHCHECK CMD ["/healthcheck.sh"]
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
     dockhand.update="false" \

--- a/Containers/clamav/Dockerfile
+++ b/Containers/clamav/Dockerfile
@@ -50,4 +50,4 @@ LABEL com.centurylinklabs.watchtower.enable="false" \
     org.opencontainers.image.source="https://github.com/nextcloud/all-in-one" \
     org.opencontainers.image.vendor="Nextcloud" \
     org.opencontainers.image.documentation="https://github.com/nextcloud/all-in-one/blob/main/readme.md"
-HEALTHCHECK --start-period=60s --retries=9 CMD /healthcheck.sh
+HEALTHCHECK --start-period=60s --retries=9 CMD ["/healthcheck.sh"]

--- a/Containers/collabora/Dockerfile
+++ b/Containers/collabora/Dockerfile
@@ -10,7 +10,7 @@ COPY --chmod=775 healthcheck.sh /healthcheck.sh
 
 USER 1001
 
-HEALTHCHECK --start-period=60s --retries=9 CMD /healthcheck.sh
+HEALTHCHECK --start-period=60s --retries=9 CMD ["/healthcheck.sh"]
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
     dockhand.update="false" \

--- a/Containers/docker-socket-proxy/Dockerfile
+++ b/Containers/docker-socket-proxy/Dockerfile
@@ -17,7 +17,7 @@ COPY --chmod=775 *.sh /
 COPY --chmod=664 haproxy.cfg /haproxy.cfg
 
 ENTRYPOINT ["/start.sh"]
-HEALTHCHECK CMD /healthcheck.sh
+HEALTHCHECK CMD ["/healthcheck.sh"]
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
     dockhand.update="false" \

--- a/Containers/domaincheck/Dockerfile
+++ b/Containers/domaincheck/Dockerfile
@@ -16,7 +16,7 @@ COPY --chmod=775 start.sh /start.sh
 USER www-data
 ENTRYPOINT ["/start.sh"]
 
-HEALTHCHECK CMD nc -z 127.0.0.1 $APACHE_PORT || exit 1
+HEALTHCHECK CMD ["sh", "-c", "nc -z 127.0.0.1 $APACHE_PORT || exit 1"]
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
     dockhand.update="false" \

--- a/Containers/eurooffice/Dockerfile
+++ b/Containers/eurooffice/Dockerfile
@@ -5,7 +5,7 @@ FROM ghcr.io/euro-office/documentserver:v9.3.3
 
 COPY --chmod=775 healthcheck.sh /healthcheck.sh
 
-HEALTHCHECK --start-period=60s --retries=9 CMD /healthcheck.sh
+HEALTHCHECK --start-period=60s --retries=9 CMD ["/healthcheck.sh"]
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
     dockhand.update="false" \

--- a/Containers/fulltextsearch/Dockerfile
+++ b/Containers/fulltextsearch/Dockerfile
@@ -18,7 +18,7 @@ COPY --chmod=775 healthcheck.sh /healthcheck.sh
 
 USER 1000:0
 
-HEALTHCHECK --interval=10s --timeout=5s --start-period=1m --retries=5 CMD /healthcheck.sh
+HEALTHCHECK --interval=10s --timeout=5s --start-period=1m --retries=5 CMD ["/healthcheck.sh"]
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
     dockhand.update="false" \

--- a/Containers/harp/Dockerfile
+++ b/Containers/harp/Dockerfile
@@ -14,4 +14,4 @@ LABEL com.centurylinklabs.watchtower.enable="false" \
     org.opencontainers.image.documentation="https://github.com/nextcloud/all-in-one/blob/main/readme.md"
 
 # Copied from upstream
-HEALTHCHECK --interval=10s --timeout=10s --retries=9 CMD /healthcheck.sh
+HEALTHCHECK --interval=10s --timeout=10s --retries=9 CMD ["/healthcheck.sh"]

--- a/Containers/imaginary/Dockerfile
+++ b/Containers/imaginary/Dockerfile
@@ -42,7 +42,7 @@ USER 65534
 ENV MALLOC_ARENA_MAX=2
 ENTRYPOINT ["/start.sh"]
 
-HEALTHCHECK CMD /healthcheck.sh
+HEALTHCHECK CMD ["/healthcheck.sh"]
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
     dockhand.update="false" \

--- a/Containers/mastercontainer/Dockerfile
+++ b/Containers/mastercontainer/Dockerfile
@@ -115,4 +115,4 @@ USER root
 
 ENTRYPOINT ["/start.sh"]
 
-HEALTHCHECK CMD /healthcheck.sh
+HEALTHCHECK CMD ["/healthcheck.sh"]

--- a/Containers/nextcloud/Dockerfile
+++ b/Containers/nextcloud/Dockerfile
@@ -9,6 +9,7 @@ ENV REDIS_DB_INDEX=0
 
 # AIO settings start # Do not remove or change this line!
 ENV NEXTCLOUD_VERSION=33.0.8
+# hadolint ignore=DL3064
 ENV AIO_TOKEN=123456
 ENV AIO_URL=localhost
 # AIO settings end # Do not remove or change this line!

--- a/Containers/nextcloud/Dockerfile
+++ b/Containers/nextcloud/Dockerfile
@@ -283,7 +283,7 @@ USER root
 ENTRYPOINT ["/start.sh"]
 CMD ["/usr/bin/supervisord", "-c", "/supervisord.conf"]
 
-HEALTHCHECK CMD /healthcheck.sh
+HEALTHCHECK CMD ["/healthcheck.sh"]
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
     dockhand.update="false" \

--- a/Containers/notify-push/Dockerfile
+++ b/Containers/notify-push/Dockerfile
@@ -20,7 +20,7 @@ RUN set -ex; \
 USER 33
 ENTRYPOINT ["/start.sh"]
 
-HEALTHCHECK CMD /healthcheck.sh
+HEALTHCHECK CMD ["/healthcheck.sh"]
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
     dockhand.update="false" \

--- a/Containers/onlyoffice/Dockerfile
+++ b/Containers/onlyoffice/Dockerfile
@@ -6,7 +6,7 @@ FROM onlyoffice/documentserver:9.3.1.2
 
 COPY --chmod=775 healthcheck.sh /healthcheck.sh
 
-HEALTHCHECK --start-period=60s --retries=9 CMD /healthcheck.sh
+HEALTHCHECK --start-period=60s --retries=9 CMD ["/healthcheck.sh"]
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
     dockhand.update="false" \

--- a/Containers/postgresql/Dockerfile
+++ b/Containers/postgresql/Dockerfile
@@ -46,7 +46,7 @@ VOLUME /mnt/data
 USER 999
 ENTRYPOINT ["/start.sh"]
 
-HEALTHCHECK CMD /healthcheck.sh
+HEALTHCHECK CMD ["/healthcheck.sh"]
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
     dockhand.update="false" \

--- a/Containers/redis/Dockerfile
+++ b/Containers/redis/Dockerfile
@@ -20,7 +20,7 @@ COPY --chmod=775 healthcheck.sh /healthcheck.sh
 USER 999
 ENTRYPOINT ["/start.sh"]
 
-HEALTHCHECK CMD /healthcheck.sh
+HEALTHCHECK CMD ["/healthcheck.sh"]
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
     dockhand.update="false" \

--- a/Containers/talk-recording/Dockerfile
+++ b/Containers/talk-recording/Dockerfile
@@ -64,7 +64,7 @@ USER 122
 ENTRYPOINT ["/start.sh"]
 CMD ["python", "-m", "nextcloud.talk.recording", "--config", "/conf/recording.conf"]
 
-HEALTHCHECK CMD /healthcheck.sh
+HEALTHCHECK CMD ["/healthcheck.sh"]
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
     dockhand.update="false" \

--- a/Containers/talk/Dockerfile
+++ b/Containers/talk/Dockerfile
@@ -109,7 +109,7 @@ USER 1000
 ENTRYPOINT ["/start.sh"]
 CMD ["supervisord", "-c", "/supervisord.conf"]
 
-HEALTHCHECK CMD /healthcheck.sh
+HEALTHCHECK CMD ["/healthcheck.sh"]
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
     dockhand.update="false" \

--- a/Containers/whiteboard/Dockerfile
+++ b/Containers/whiteboard/Dockerfile
@@ -16,7 +16,7 @@ USER 65534
 COPY --chmod=775 start.sh /start.sh
 COPY --chmod=775 healthcheck.sh /healthcheck.sh
 
-HEALTHCHECK CMD /healthcheck.sh
+HEALTHCHECK CMD ["/healthcheck.sh"]
 
 WORKDIR /tmp
 


### PR DESCRIPTION
Fixes hadolint's complains as visible e.g. in https://github.com/nextcloud/all-in-one/actions/runs/32381178668/job/96464481888

1. Converts all shell-form HEALTHCHECK CMD instructions to exec (JSON
array) form. The domaincheck healthcheck relies on shell expansion and
the || operator, so it is wrapped as CMD ["sh", "-c", "..."] to preserve
behavior.
2. Makes hadolint ignore [DL3064](https://github.com/hadolint/hadolint/wiki/DL3064) in one case, where we assign a dummy value to the `AIO_TOKEN` environment variable. (I'm not sure why we do that but I don't dare to change that now.)

## Summary
- [ ] The PR was tested and verified that it works locally
- [ ] Or will be tested after merge on a dedicated test instance (available for maintainers)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests (playwright if possible) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation has been updated or is not required
- [ ] [Labels added](https://github.com/nextcloud/all-in-one/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone next added](https://github.com/nextcloud/all-in-one/milestones)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
