### PR TITLE
feat(containers): clarify next major early access wording

### DIFF
--- a/php/templates/containers.twig
+++ b/php/templates/containers.twig
@@ -313,15 +313,34 @@
                             {% endif %}
                         {% else %}
                             {% if is_mastercontainer_update_available == false %}
-                                <p>Your containers are up-to-date.</p>
+                                <p>Your AIO containers are up-to-date.</p>
                                 {% if newMajorVersionString != '' and isAnyRunning == true and isApacheStarting != true %}
                                     <details>
-                                    <summary>Note about <strong>Nextcloud Hub {{ newMajorVersionString }}</strong></summary>
-<p>If you haven't upgraded to Nextcloud Hub {{ newMajorVersionString }} yet and want to do that now, feel free to click the button below. ⚠️ Warning: make sure to create a backup before clicking the button as the update can go wrong and will leave your instance in a broken state!</p>
+                                        <summary>Note about <strong>Nextcloud Hub {{ newMajorVersionString }} (optional early access)</strong></summary>
+                                        <p>
+                                            If you haven't already upgraded to Nextcloud Hub {{ newMajorVersionString }} and would like to do
+                                            so before it becomes the default major version used in AIO, you may click the button below to do so.
+                                        </p>
+
+                                        <p>
+                                            If you have already upgraded your instance to the {{ newMajorVersionString }} Hub series and are
+                                            notified about a new maintenance release being available for it, clicking here will install it. Once
+                                            {{ newMajorVersionString }} Hub series is mature enough to become the default Nextcloud version in AIO,
+                                            this section will disappear and you can return to applying the latest maintenance and security fixes in
+                                            the standard AIO manner.
+                                        </p>
+
+                                        <p>
+                                            ⚠️ Please create a backup before continuing. An update can fail and leave your instance in a 
+                                            broken state.
+                                        </p>
+        
                                         <form method="POST" action="api/docker/nextcloud-upgrade-to-latest-major" target="overlay-log">
-                                            <input type="hidden" name="{{csrf.keys.name}}" value="{{csrf.name}}">
-                                            <input type="hidden" name="{{csrf.keys.value}}" value="{{csrf.value}}">
-                                            <input type="submit" value="Upgrade to Nextcloud Hub {{ newMajorVersionString }}" data-confirm="Upgrade to Nextcloud Hub {{ newMajorVersionString }}? You should consider creating a backup first." />
+                                            <input type="hidden" name="{{ csrf.keys.name }}" value="{{ csrf.name }}">
+                                            <input type="hidden" name="{{ csrf.keys.value }}" value="{{ csrf.value }}">
+                                            <input type="submit" 
+                                               value="Upgrade to Nextcloud Hub {{ newMajorVersionString }}" 
+                                               data-confirm="Upgrade Nextcloud to the latest Hub {{ newMajorVersionString }} release? You should consider creating a backup first." />
                                         </form>
                                     </details>
                                 {% endif %}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud AIO instances and users in the meantime.
-->

- Resolves: # <!-- related github issue -->

## Summary

Until we expose more versioning info to the templates adjust the logic, this should clarify the messaging a bit when we offer early access to a new major release prior to it being the default in AIO. Or at least that's the idea.

Changes:

- Clarify what the note is about in its heading
- Clarify it can be used to upgrade to the a not-yet-default major version
- Clarify that when using this "early access" feature, this must also be utilized to upgrade to new maintenance releases 
- Tighten up some wording
- Tidy up some formatting

## Checklist

- [ ] The PR was tested and verified that it works locally
- [ ] Or will be tested after merge on a dedicated test instance (available for maintainers)
- [ ] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests (playwright if possible) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation has been updated or is not required
- [x] [Labels added](https://github.com/nextcloud/all-in-one/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone next added](https://github.com/nextcloud/all-in-one/milestones)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
