### PR TITLE
Reverse proxy docs - Add comment to use Docker DNS in nginx config example

### DIFF
--- a/reverse-proxy.md
+++ b/reverse-proxy.md
@@ -527,6 +527,8 @@ server {
     server_name <your-nc-domain>;
 
     location / {
+        # resolver 127.0.0.11  # uncomment to use Docker's DNS to resolve nextcloud-aio container name
+
         proxy_pass http://127.0.0.1:11000$request_uri; # Adjust to match APACHE_PORT and APACHE_IP_BINDING. See https://github.com/nextcloud/all-in-one/blob/main/reverse-proxy.md#adapting-the-sample-web-server-configurations-below
 
         proxy_set_header X-Forwarded-Host $host;


### PR DESCRIPTION
Hi,

Thanks for your work on this great project!

The reverse proxy docs describe how to adapt the sample web server configuration in a scenario where the reverse proxy is running on the same server in a Docker container. In this scenario there are three options, the first one relying on host networking, and the next two relying on Docker bridge network's DNS name resolution.

I used the Docker bridge network's DNS method with nginx. But without explicitly telling nginx to use the Docker DNS server with a `resolver 127.0.0.11` directive, this method fails with the nginx logs giving "no resolver defined to resolve nextcloud-aio-apache".
The `resolver` directive is not mentioned in the nginx config example. Adding it as an optional/commented line could help.

- It does add yet another optional/commented line in the config example, so I guess adding this is a compromise between 1/ keeping the example simple and letting the user adapt by themself versus 2/ helping the user by making the example exhaustive at the risk of cluttering with too much information.

- I'm not an expert of nginx in Docker containers, it's possible that some other aspect of my setup made this `resolver 127.0.0.11` directive necessary.

- Resolves: #

## Summary
- [ ] The PR was tested and verified that it works locally
- [ ] Or will be tested after merge on a dedicated test instance (available for maintainers)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests (playwright if possible) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation has been updated or is not required
- [x] [Labels added](https://github.com/nextcloud/all-in-one/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone next added](https://github.com/nextcloud/all-in-one/milestones)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
