### PR TITLE
nextcloud: upgrade PHP to 8.4

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -44,6 +44,16 @@ jobs:
         )"
         sed -i "s|pecl install APCu.*\;|pecl install APCu-$apcu_version\;|" ./Containers/mastercontainer/Dockerfile
 
+        imap_version="$(
+          git ls-remote --tags https://github.com/php/pecl-mail-imap.git \
+            | cut -d/ -f3 \
+            | grep -viE -- 'rc|alpha|beta|\^' \
+            | sed -E 's/^v//' \
+            | sort -V \
+            | tail -1
+        )"
+        sed -i "s|\(pecl install -D 'with-kerberos=\"yes\" with-imap-ssl=\"yes\"' imap\)-.*\;|\1-$imap_version\;|" ./Containers/nextcloud/Dockerfile
+
         # CADDY_REMOTE_HOST_HASH
         CADDY_REMOTE_HOST_HASH="$(
           git ls-remote https://github.com/muety/caddy-remote-host master \

--- a/Containers/nextcloud/Dockerfile
+++ b/Containers/nextcloud/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:latest
-FROM php:8.3.33-fpm-alpine3.24
+FROM php:8.4.24-fpm-alpine3.24
 
 ENV PHP_MEMORY_LIMIT=512M
 ENV PHP_UPLOAD_LIMIT=16G
@@ -70,7 +70,7 @@ RUN set -ex; \
     ; \
     \
     docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
-    docker-php-ext-configure ftp --with-openssl-dir=/usr; \
+    docker-php-ext-configure ftp --with-ftp-ssl; \
     docker-php-ext-configure ldap; \
     docker-php-ext-install -j "$(nproc)" \
         bcmath \
@@ -205,15 +205,15 @@ RUN set -ex; \
         libpq-dev \
     ; \
     \
-    docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
     docker-php-ext-install \
         bz2 \
-        imap \
         pgsql \
         ftp \
     ; \
+# imap was removed from PHP core in 8.4, so it needs to be installed from PECL from now on
+    pecl install -D 'with-kerberos="yes" with-imap-ssl="yes"' imap-1.0.3; \
     pecl install smbclient; \
-    docker-php-ext-enable smbclient; \
+    docker-php-ext-enable imap smbclient; \
     \
     runDeps="$( \
         scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \


### PR DESCRIPTION
- Close https://github.com/nextcloud/all-in-one/issues/5555

## Summary
- [ ] The PR was tested and verified that it works locally
- [x] Or will be tested after merge on a dedicated test instance (available for maintainers)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests (playwright if possible) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation has been updated or is not required
- [x] [Labels added](https://github.com/nextcloud/all-in-one/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone next added](https://github.com/nextcloud/all-in-one/milestones)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
