### PR TITLE
aio-interface: Remove migration code for the session cookie rename

### DIFF
--- a/php/public/index.php
+++ b/php/public/index.php
@@ -40,24 +40,6 @@ $container->set(Guard::class, function () use ($responseFactory) {
 });
 
 // Register Middleware To Be Executed On All Routes
-
-// Migrate from the old PHPSESSID cookie to the new __Host-Http-PHPSESSID cookie.
-// This is needed because the session cookie was renamed in a previous release. Without this,
-// users that were logged in before the update would be logged out after the container restarts.
-$wasAuthenticated = false;
-$oldSessionTimestamp = null;
-if (!isset($_COOKIE['__Host-Http-PHPSESSID']) && isset($_COOKIE['PHPSESSID'])) {
-    session_name('PHPSESSID');
-    if (session_start(['save_path' => $dataConst->GetSessionDirectory(), 'use_strict_mode' => true])) {
-        $wasAuthenticated = isset($_SESSION[\AIO\Auth\AuthManager::SESSION_KEY]) && $_SESSION[\AIO\Auth\AuthManager::SESSION_KEY] === true;
-        $oldSessionTimestamp = isset($_SESSION['date_time']) ? (int)$_SESSION['date_time'] : null;
-        // Do not destroy the old session: if the response carrying the new __Host-Http-PHPSESSID
-        // cookie is lost (e.g., due to a 502 during a mastercontainer update), the client can
-        // retry with the old PHPSESSID cookie and still be authenticated.
-        session_write_close();
-    }
-}
-
 session_start([
     "name" => "__Host-Http-PHPSESSID", // Set cookie prefix to prevent other pages from overwriting this cookie. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#cookie_prefixes
     "save_path" => $dataConst->GetSessionDirectory(), // Where to save the session files
@@ -71,17 +53,6 @@ session_start([
     "cookie_samesite" => "Lax", // Send the cookie with same-site requests and top-level cross-site navigations (e.g. redirect after token-based getlogin). "Strict" would block the session cookie on the redirect that follows a cross-site navigation, breaking the getlogin flow from Nextcloud's admin panel. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value
 ]);
 
-if ($wasAuthenticated) {
-    if ($oldSessionTimestamp !== null) {
-        // Use MigrateAuthState to preserve the original login timestamp. This prevents the
-        // session deduplicator from running and keeps the old PHPSESSID session file alive,
-        // so the client can retry with the old cookie if the 502 response causes the new
-        // __Host-Http-PHPSESSID cookie to not be received.
-        $container->get(\AIO\Auth\AuthManager::class)->MigrateAuthState($oldSessionTimestamp);
-    } else {
-        $container->get(\AIO\Auth\AuthManager::class)->SetAuthState(true);
-    }
-}
 $app->add(Guard::class);
 
 // Create Twig

--- a/php/src/Auth/AuthManager.php
+++ b/php/src/Auth/AuthManager.php
@@ -8,7 +8,7 @@ use AIO\Data\DataConst;
 use \DateTime;
 
 readonly class AuthManager {
-    public const string SESSION_KEY = 'aio_authenticated';
+    private const string SESSION_KEY = 'aio_authenticated';
 
     public function __construct(
         private ConfigurationManager $configurationManager
@@ -40,18 +40,6 @@ readonly class AuthManager {
         }
 
         $_SESSION[self::SESSION_KEY] = $isLoggedIn;
-    }
-
-    /**
-     * Migrates the authenticated state from an old session (different cookie name) to the new session.
-     * Unlike SetAuthState, this method preserves the original login timestamp and does not update
-     * the session_date_file, so the session deduplicator is not triggered. This keeps the old session
-     * file alive in case the response carrying the new cookie is lost (e.g., due to a 502 error during
-     * a mastercontainer update), allowing the client to retry with the old cookie.
-     */
-    public function MigrateAuthState(int $oldTimestamp) : void {
-        $_SESSION[self::SESSION_KEY] = true;
-        $_SESSION['date_time'] = $oldTimestamp;
     }
 
     public function IsAuthenticated() : bool {


### PR DESCRIPTION
The session cookie was renamed from PHPSESSID to __Host-Http-PHPSESSID in v13.0.0 and PRs #7964 and #7971 added transitional code that carried an existing PHPSESSID login over to the new cookie. Everyone has long since been migrated, so this reverts both PRs.

- Closes #7966



## Summary
- [ ] The PR was tested and verified that it works locally
- [x] Or will be tested after merge on a dedicated test instance (available for maintainers)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests (playwright if possible) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation has been updated or is not required
- [x] [Labels added](https://github.com/nextcloud/all-in-one/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone next added](https://github.com/nextcloud/all-in-one/milestones)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
