### PR TITLE
aio-interface: hide temporary upgrade button and links

### DIFF
--- a/php/templates/containers.twig
+++ b/php/templates/containers.twig
@@ -37,8 +37,8 @@
             {% set isBackupOrRestoreRunning = false %}
             {% set isApacheStarting = false %}
             {# Setting newMajorVersion to '' will hide corresponding options/elements, can be set to an integer like 26 in order to show corresponding elements. If set, also increase installLatestMajor in https://github.com/nextcloud/all-in-one/blob/main/php/src/Controller/DockerController.php #}
-            {% set newMajorVersionString = '26 Spring' %}
-            {% set oldMajorVersionString = '25 Autumn' %}
+            {% set newMajorVersionString = '' %}
+            {% set oldMajorVersionString = '' %}
 
             {% if is_backup_container_running == true %}
                 {% if borg_backup_mode == 'backup' or borg_backup_mode == 'restore' %}


### PR DESCRIPTION
- Close part of https://github.com/nextcloud/all-in-one/issues/8327

## Summary
- [ ] The PR was tested and verified that it works locally
- [x] Or will be tested after merge on a dedicated test instance (available for maintainers)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests (playwright if possible) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation has been updated or is not required
- [x] [Labels added](https://github.com/nextcloud/all-in-one/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone next added](https://github.com/nextcloud/all-in-one/milestones)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
