### PR TITLE
allow to adjust the log level for all caddy instances

### DIFF
--- a/Containers/apache/Caddyfile
+++ b/Containers/apache/Caddyfile
@@ -11,13 +11,15 @@
         # trusted_proxies placeholder
     }
 
-    # The endpoint below is plain http on purpose, so limit it to h1 to avoid caddy warning that
-    # HTTP/2 and HTTP/3 were skipped. Excluding the `http` logger would also hide acme messages.
+    # Plain http on purpose, so limit it to h1 to avoid caddy warning that HTTP/2 and HTTP/3 were
+    # skipped. Excluding the `http` logger would also hide acme messages.
     servers :23973 {
         protocols h1
+        # A scoped block overrides the address-less one above, so repeat trusted_proxies here.
+        # trusted_proxies placeholder
     }
 
-    # apache-port protocols placeholder
+    # apache-port servers placeholder
 
     log {
         level {$CADDY_LOG_LEVEL}

--- a/Containers/apache/Caddyfile
+++ b/Containers/apache/Caddyfile
@@ -1,4 +1,6 @@
 {
+    admin off
+
     auto_https disable_redirects
 
     storage file_system {
@@ -9,8 +11,19 @@
         # trusted_proxies placeholder
     }
 
+    # The endpoint below is plain http on purpose, so limit it to h1 to avoid caddy warning that
+    # HTTP/2 and HTTP/3 were skipped. Excluding the `http` logger would also hide acme messages.
+    servers :23973 {
+        protocols h1
+    }
+
+    # apache-port protocols placeholder
+
     log {
-        level ERROR
+        level {$CADDY_LOG_LEVEL}
+        # Below ERROR, caddy prints 'admin endpoint disabled' on every start, which is expected
+        # since we set `admin off` above.
+        exclude admin
     }
 }
 

--- a/Containers/apache/start.sh
+++ b/Containers/apache/start.sh
@@ -56,22 +56,25 @@ else
 fi
 echo "$CADDYFILE" > /tmp/Caddyfile
 
-# Change the trusted_proxies in case of reverse proxies
+# Determine the trusted_proxies in case of reverse proxies
 if [ "$APACHE_PORT" != '443' ]; then
     # Here the 100.64.0.0/10 range gets added which is the CGNAT range used by Tailscale nodes
     # See https://github.com/nextcloud/all-in-one/pull/6703 for reference
-    CADDYFILE="$(sed 's|# trusted_proxies placeholder|trusted_proxies static private_ranges 100.64.0.0/10|' /tmp/Caddyfile)"
+    TRUSTED_PROXIES="trusted_proxies static private_ranges 100.64.0.0/10"
 else
-    CADDYFILE="$(sed "s|# trusted_proxies placeholder|trusted_proxies static $IPv4_ADDRESS|" /tmp/Caddyfile)"
+    TRUSTED_PROXIES="trusted_proxies static $IPv4_ADDRESS"
 fi
-echo "$CADDYFILE" > /tmp/Caddyfile
 
 # In case of reverse proxies the APACHE_PORT listener is plain http, so limit it to h1 to avoid
 # caddy warning that HTTP/2 and HTTP/3 were skipped. See the Caddyfile for further details.
 if [ "$APACHE_PORT" != '443' ]; then
-    CADDYFILE="$(sed "s|# apache-port protocols placeholder|servers :$APACHE_PORT {\n\t\tprotocols h1\n\t}|" /tmp/Caddyfile)"
+    CADDYFILE="$(sed "s|# apache-port servers placeholder|servers :$APACHE_PORT {\n\t\tprotocols h1\n\t\t# trusted_proxies placeholder\n\t}|" /tmp/Caddyfile)"
     echo "$CADDYFILE" > /tmp/Caddyfile
 fi
+
+# Change all trusted_proxies placeholders, also the ones inside the scoped `servers` blocks
+CADDYFILE="$(sed "s|# trusted_proxies placeholder|$TRUSTED_PROXIES|g" /tmp/Caddyfile)"
+echo "$CADDYFILE" > /tmp/Caddyfile
 
 # Remove additional domain if not given
 if [ -z "$ADDITIONAL_TRUSTED_DOMAIN" ]; then

--- a/Containers/apache/start.sh
+++ b/Containers/apache/start.sh
@@ -9,6 +9,8 @@ if [ -z "$NC_DOMAIN" ]; then
     exit 1
 fi
 
+CADDY_LOG_LEVEL="$(echo "$AIO_LOG_LEVEL" | tr '[:lower:]' '[:upper:]')"
+export CADDY_LOG_LEVEL
 if [ "$AIO_LOG_LEVEL" = 'debug' ]; then
     export AIO_ACCESS_LOG=/proc/self/fd/1
 else
@@ -63,6 +65,13 @@ else
     CADDYFILE="$(sed "s|# trusted_proxies placeholder|trusted_proxies static $IPv4_ADDRESS|" /tmp/Caddyfile)"
 fi
 echo "$CADDYFILE" > /tmp/Caddyfile
+
+# In case of reverse proxies the APACHE_PORT listener is plain http, so limit it to h1 to avoid
+# caddy warning that HTTP/2 and HTTP/3 were skipped. See the Caddyfile for further details.
+if [ "$APACHE_PORT" != '443' ]; then
+    CADDYFILE="$(sed "s|# apache-port protocols placeholder|servers :$APACHE_PORT {\n\t\tprotocols h1\n\t}|" /tmp/Caddyfile)"
+    echo "$CADDYFILE" > /tmp/Caddyfile
+fi
 
 # Remove additional domain if not given
 if [ -z "$ADDITIONAL_TRUSTED_DOMAIN" ]; then

--- a/Containers/mastercontainer/acme.Caddyfile
+++ b/Containers/mastercontainer/acme.Caddyfile
@@ -10,10 +10,16 @@
 	}
 
 	log {
-		level ERROR
+		level {$CADDY_LOG_LEVEL}
 		# We need to exclude the remote-host plugin from logging as it would spam the logs
 		# See https://github.com/nextcloud/all-in-one/pull/7006#issuecomment-4003238239 
 		exclude http.matchers.remote_host
+		# Below ERROR, caddy prints 'admin endpoint disabled' on every start, which is expected
+		# since we set `admin off` above. The on-demand TLS warning is suppressed by the `ask` below.
+		exclude admin
+		# Below ERROR, caddy warns that the `http://:80` block only listens on the HTTP port, which
+		# is expected as it merely redirects to https while `https://:8443` handles the certificates.
+		exclude http.auto_https
 	}
 
 	servers {

--- a/Containers/mastercontainer/internal.Caddyfile
+++ b/Containers/mastercontainer/internal.Caddyfile
@@ -9,15 +9,27 @@
 	}
 
 	log {
-		level ERROR
+		level {$CADDY_LOG_LEVEL}
 		# We need to exclude the remote-host plugin from logging as it would spam the logs
 		# See https://github.com/nextcloud/all-in-one/pull/7006#issuecomment-4003238239 
 		exclude http.matchers.remote_host
+		# Below ERROR, caddy prints 'admin endpoint disabled' on every start, which is expected
+		# since we set `admin off` above.
+		exclude admin
+		# Below ERROR, caddy reports that the http -> https redirects are disabled, which is
+		# expected since we set `auto_https disable_redirects` above (acme.Caddyfile handles them).
+		exclude http.auto_https
 	}
 
 	servers {
 		# Only h1 is allowed as we prevent `ERR_NETWORK_CHANGED` from happening
 		protocols h1
+	}
+
+	# This endpoint always allows as the internal issuer below only creates self-signed certificates.
+	# It is only needed to silence caddy's warning about unprotected on-demand TLS.
+	on_demand_tls {
+		ask http://127.0.0.1:9876/internal
 	}
 
 	skip_install_trust

--- a/Containers/mastercontainer/start.sh
+++ b/Containers/mastercontainer/start.sh
@@ -352,6 +352,9 @@ if [ "$AIO_LOG_LEVEL" != 'debug' ]; then
     sed -i 's|^options = shares-console|#options = shares-console|' /etc/dinit.d/domain-validator
 fi
 
+CADDY_LOG_LEVEL="$(echo "$AIO_LOG_LEVEL" | tr '[:lower:]' '[:upper:]')"
+export CADDY_LOG_LEVEL
+
 # Check if ghcr.io is reachable
 # Solves issues like https://github.com/nextcloud/all-in-one/discussions/5268
 if ! curl --no-progress-meter https://ghcr.io/v2/ >/dev/null; then

--- a/php/domain-validator.php
+++ b/php/domain-validator.php
@@ -6,7 +6,11 @@ if (isset($_GET['domain']) && is_string($_GET['domain'])) {
     $domain = $_GET['domain'];
 }
 
-if (!str_contains($domain, '.')) { 
+// The internal caddy instance on port 8080 accepts any hostname as it only issues self-signed
+// certificates. It needs this endpoint to silence caddy's unprotected on-demand TLS warning.
+if (($_SERVER['REQUEST_URI'] ?? '') === '/internal' || str_starts_with($_SERVER['REQUEST_URI'] ?? '', '/internal?')) {
+    http_response_code(200);
+} elseif (!str_contains($domain, '.')) {
     http_response_code(400);
 } elseif (str_contains($domain, '/')) { 
     http_response_code(400);


### PR DESCRIPTION
- Close https://github.com/nextcloud/all-in-one/issues/8026

## Summary
- [ ] The PR was tested and verified that it works locally
- [x] Or will be tested after merge on a dedicated test instance (available for maintainers)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests (playwright if possible) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation has been updated or is not required
- [x] [Labels added](https://github.com/nextcloud/all-in-one/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone next added](https://github.com/nextcloud/all-in-one/milestones)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
