### PR TITLE
keep the dinit socket in /run

### DIFF
--- a/Containers/apache/Dockerfile
+++ b/Containers/apache/Dockerfile
@@ -83,6 +83,7 @@ RUN set -ex; \
     mkdir -p /usr/local/apache2/logs; \
     chmod 777 -R /home/www-data; \
     chmod 777 -R /usr/local/apache2/logs; \
+    chmod 777 /run; \
     rm -rf /usr/local/apache2/cgi-bin/
 
 USER www-data:www-data
@@ -90,7 +91,7 @@ USER www-data:www-data
 STOPSIGNAL SIGTERM
 
 ENTRYPOINT ["/start.sh"]
-CMD ["dinit", "--system", "--container", "--socket-path", "/tmp/dinitctl", "apache", "caddy"]
+CMD ["dinit", "--system", "--container", "apache", "caddy"]
 
 ENV AIO_LOG_LEVEL=warn
 

--- a/Containers/clamav/Dockerfile
+++ b/Containers/clamav/Dockerfile
@@ -6,6 +6,7 @@ RUN set -ex; \
     apk add --no-cache tzdata clamav clamav-milter dinit bash; \
     mkdir -p /tmp /var/lib/clamav; \
     chmod 777 -R /tmp /var/log/clamav; \
+    chmod 777 /run; \
     chown -R clamav:clamav /var/lib/clamav; \
     sed -i "s|#\?MaxDirectoryRecursion.*|MaxDirectoryRecursion 30|g" /etc/clamav/clamd.conf; \
     sed -i "s|#\?MaxScanSize.*|MaxScanSize 2000M|g" /etc/clamav/clamd.conf; \
@@ -43,7 +44,7 @@ RUN set -ex; \
     freshclam --foreground --stdout
 VOLUME /var/lib/clamav
 ENTRYPOINT ["/start.sh"]
-CMD ["dinit", "--system", "--container", "--socket-path", "/tmp/dinitctl", "freshclam", "clamd", "milter"]
+CMD ["dinit", "--system", "--container", "freshclam", "clamd", "milter"]
 LABEL com.centurylinklabs.watchtower.enable="false" \
     wud.watch="false" \
     dockhand.update="false" \

--- a/Containers/talk/Dockerfile
+++ b/Containers/talk/Dockerfile
@@ -72,12 +72,13 @@ RUN set -ex; \
     chmod 777 -R \
         /tmp \
         /conf; \
+    chmod 777 /run; \
     ln -s /opt/eturnal/bin/stun /usr/local/bin/stun; \
     ln -s /opt/eturnal/bin/eturnalctl /usr/local/bin/eturnalctl
 
 USER eturnal:eturnal
 ENTRYPOINT ["/start.sh"]
-CMD ["dinit", "--system", "--container", "--socket-path", "/tmp/dinitctl", "nats-server", "eturnal", "janus", "signaling"]
+CMD ["dinit", "--system", "--container", "nats-server", "eturnal", "janus", "signaling"]
 
 HEALTHCHECK CMD ["/healthcheck.sh"]
 LABEL com.centurylinklabs.watchtower.enable="false" \


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud AIO instances and users in the meantime.
-->

- Resolves: https://github.com/nextcloud/all-in-one/pull/8634#issuecomment-5437583510

## Summary
- [ ] The PR was tested and verified that it works locally
- [ ] Or will be tested after merge on a dedicated test instance (available for maintainers)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests (playwright if possible) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation has been updated or is not required
- [x] [Labels added](https://github.com/nextcloud/all-in-one/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone next added](https://github.com/nextcloud/all-in-one/milestones)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
