### PR TITLE
eurooffice: persist sdkjs-plugins as a named volume

### DIFF
--- a/Containers/eurooffice/Dockerfile
+++ b/Containers/eurooffice/Dockerfile
@@ -4,6 +4,10 @@ FROM ghcr.io/euro-office/documentserver:v9.3.3
 # USER root is probably used
 
 COPY --chmod=775 healthcheck.sh /healthcheck.sh
+# Make sdkjs-plugins writable so it can be mounted as a persistent named
+# volume (upstream image ships it read-only, dr-xr-xr-x, owned by ds:ds)
+RUN chown ds:ds /var/www/euro-office/documentserver/sdkjs-plugins \
+    && chmod 755 /var/www/euro-office/documentserver/sdkjs-plugins
 
 HEALTHCHECK --start-period=60s --retries=9 CMD ["/healthcheck.sh"]
 LABEL com.centurylinklabs.watchtower.enable="false" \

--- a/php/containers.json
+++ b/php/containers.json
@@ -796,6 +796,11 @@
           "source": "nextcloud_aio_eurooffice_data",
           "destination": "/var/www/euro-office/Data",
           "writeable": true
+        },
+  	{
+	  "source": "nextcloud_aio_eurooffice_plugins",
+          "destination": "/var/www/euro-office/documentserver/sdkjs-plugins",
+          "writeable": true
         }
       ],
       "secrets": [


### PR DESCRIPTION
Fixes #8616 by creating persistent volume for Euro-Office plugins

- Resolves: #8616

## Summary

The EuroOffice DocumentServer image ships the `sdkjs-plugins` directory
read-only (`dr-xr-xr-x`, owned by `ds:ds`), and it isn't backed by a
volume. Any plugin installed into that directory is lost whenever the
eurooffice container is recreated (e.g. on update).

This PR:
- Adds a named volume (`nextcloud_aio_eurooffice_plugins`) mounted into
  `/var/www/euro-office/documentserver/sdkjs-plugins` in
  `php/containers.json`, following the same pattern as the existing
  `nextcloud_aio_eurooffice_data` volume added in #8512.
- Fixes ownership/permissions for that directory in the Dockerfile so
  the `ds` user (which the document server process actually runs as)
  can write to it. Mounting the volume alone is not sufficient, since
  Docker preserves the read-only permissions of the original directory
  when initializing a new named volume.

### Testing performed
Built the eurooffice image locally and tested outside of AIO's
orchestration, directly against the named volume:
1. Created the named volume and started the built image with it mounted.
2. Confirmed the `ds` user can write to the directory (`touch` succeeds,
   `ls -la` shows `drwxr-xr-x` instead of `dr-xr-xr-x`).
3. Removed and recreated the container against the same volume
   (`docker rm` + `docker run`, simulating an AIO container update) and
   confirmed the test file written in step 2 survived.

- [x] The PR was tested and verified that it works locally
- [ ] Or will be tested after merge on a dedicated test instance (available for maintainers)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests (playwright if possible) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation has been updated or is not required
- [x] [Labels added](https://github.com/nextcloud/all-in-one/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone next added](https://github.com/nextcloud/all-in-one/milestones)
## AI (if applicable)
- [x] the creation of this pull request was aided by AI. 
Used Claude to help identify the fix (following the pattern from #8512)
and draft the containers.json/Dockerfile changes. I reviewed and
verified all code myself, and performed all testing (local image
build, volume mount, permission check, container recreation test)
manually on my own machine — none of that was run by the AI.