### PR TITLE
some preparations for `Nextcloud Hub 26 Summer`

### DIFF
--- a/app/appinfo/info.xml
+++ b/app/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Nextcloud All-in-One</name>
 	<summary>Provides a login link for admins.</summary>
 	<description>Add a link to the admin settings that gives access to the Nextcloud All-in-One admin interface</description>
-	<version>0.8.0</version>
+	<version>0.9.0</version>
 	<licence>agpl</licence>
 	<author>Azul</author>
 	<namespace>AllInOne</namespace>
@@ -13,7 +13,7 @@
 	<category>monitoring</category>
 	<bugs>https://github.com/nextcloud/all-in-one/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="33" max-version="34"/>
+		<nextcloud min-version="34" max-version="35"/>
 	</dependencies>
 
 	<settings>

--- a/php/src/Controller/DockerController.php
+++ b/php/src/Controller/DockerController.php
@@ -16,7 +16,7 @@ use Slim\Psr7\NonBufferedBody;
 
 readonly class DockerController {
     private const string TOP_CONTAINER = 'nextcloud-aio-apache';
-    private const string LATEST_MAJOR_VERSION = '34';
+    private const string LATEST_MAJOR_VERSION = '35';
 
     public function __construct(
         private DockerActionManager           $dockerActionManager,

--- a/php/templates/containers.twig
+++ b/php/templates/containers.twig
@@ -37,8 +37,8 @@
             {% set isBackupOrRestoreRunning = false %}
             {% set isApacheStarting = false %}
             {# Setting newMajorVersion to '' will hide corresponding options/elements, can be set to an integer like 26 in order to show corresponding elements. If set, also increase installLatestMajor in https://github.com/nextcloud/all-in-one/blob/main/php/src/Controller/DockerController.php #}
-            {% set newMajorVersionString = '' %}
-            {% set oldMajorVersionString = '' %}
+            {% set newMajorVersionString = '26 Summer' %}
+            {% set oldMajorVersionString = '26 Spring' %}
 
             {% if is_backup_container_running == true %}
                 {% if borg_backup_mode == 'backup' or borg_backup_mode == 'restore' %}


### PR DESCRIPTION

## Summary
- [ ] The PR was tested and verified that it works locally
- [x] Or will be tested after merge on a dedicated test instance (available for maintainers)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests (playwright if possible) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation has been updated or is not required
- [x] [Labels added](https://github.com/nextcloud/all-in-one/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone next added](https://github.com/nextcloud/all-in-one/milestones)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
