### PR TITLE
pin the playwright workflow dispatch to ubuntu 26.04 for now

### DIFF
--- a/.github/workflows/playwright-on-workflow-dispatch.yml
+++ b/.github/workflows/playwright-on-workflow-dispatch.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     timeout-minutes: 60
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION

## Summary
- [x] The PR was tested and verified that it works locally
- [ ] Or will be tested after merge on a dedicated test instance (available for maintainers)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests (playwright if possible) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation has been updated or is not required
- [x] [Labels added](https://github.com/nextcloud/all-in-one/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone next added](https://github.com/nextcloud/all-in-one/milestones)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
