### PR TITLE
Rename "Nextcloud Office (Collabora)" by "Collabora Online"

### DIFF
--- a/community-containers/languagetool/readme.md
+++ b/community-containers/languagetool/readme.md
@@ -1,9 +1,9 @@
-## LanguageTool for Nextcloud Office
-This container bundles [LanguageTool](https://github.com/languagetool-org/languagetool) for Nextcloud Office which adds spell checking functionality to Nextcloud Office.
+## LanguageTool for Collabora Online
+This container bundles [LanguageTool](https://github.com/languagetool-org/languagetool) for Collabora Online which adds spell checking functionality to Collabora Online.
 
 ### Notes
-- Make sure to have Nextcloud Office enabled via the AIO interface
-- After adding this container via the AIO Interface, while all containers are still stopped, you need to scroll down to the `Additional Nextcloud Office options` section and enter `--o:languagetool.enabled=true --o:languagetool.base_url=http://nextcloud-aio-languagetool:8010/v2`.
+- Make sure to have Collabora Online enabled via the AIO interface
+- After adding this container via the AIO Interface, while all containers are still stopped, you need to scroll down to the `Additional Collabora Online options` section and enter `--o:languagetool.enabled=true --o:languagetool.base_url=http://nextcloud-aio-languagetool:8010/v2`.
 - See https://github.com/nextcloud/all-in-one/tree/main/community-containers#community-containers how to add it to the AIO stack
 
 ### Repository

--- a/php/containers.json
+++ b/php/containers.json
@@ -374,7 +374,7 @@
       "container_name": "nextcloud-aio-collabora",
       "image_tag": "%AIO_CHANNEL%",
       "documentation": "https://github.com/nextcloud/all-in-one/discussions/1358",
-      "display_name": "Nextcloud Office",
+      "display_name": "Collabora Online",
       "image": "ghcr.io/nextcloud-releases/aio-collabora",
       "init": true,
       "healthcheck": {
@@ -763,7 +763,7 @@
     {
       "container_name": "nextcloud-aio-eurooffice",
       "image_tag": "%AIO_CHANNEL%",
-      "display_name": "EuroOffice",
+      "display_name": "Nextcloud Office",
       "image": "ghcr.io/nextcloud-releases/aio-eurooffice",
       "init": true,
       "healthcheck": {

--- a/php/public/style.css
+++ b/php/public/style.css
@@ -702,8 +702,9 @@ body.modal-open {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    /* Reserve the vendor-line slot so cards with and without one keep their
-       titles, checkmarks and feature lists on the same baseline. */
+    /* Reserve the vendor-line slot so a card without one keeps its title and
+       feature list level with the cards that have one.
+       44px = 24px title height + 4px vendor-line margin + 16px vendor line. */
     min-height: 44px;
     margin-bottom: 16px;
 }
@@ -726,6 +727,7 @@ body.modal-open {
 
 .office-checkmark {
     flex-shrink: 0;
+    align-self: center;
     display: none;
 }
 

--- a/php/public/style.css
+++ b/php/public/style.css
@@ -701,7 +701,10 @@ body.modal-open {
 .office-card-header {
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start;
+    /* Reserve the vendor-line slot so cards with and without one keep their
+       titles, checkmarks and feature lists on the same baseline. */
+    min-height: 44px;
     margin-bottom: 16px;
 }
 
@@ -716,6 +719,7 @@ body.modal-open {
 .office-powered-by {
     margin: 4px 0 0;
     font-size: 13px;
+    line-height: 16px;
     color: var(--color-main-text);
     opacity: 0.7;
 }

--- a/php/templates/includes/optional-containers.twig
+++ b/php/templates/includes/optional-containers.twig
@@ -28,7 +28,6 @@
             <div class="office-card-header">
                 <div>
                     <h4>Nextcloud Office</h4>
-                    <p class="office-powered-by">powered by Euro-Office</p>
                 </div>
                 <svg class="office-checkmark" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <circle cx="12" cy="12" r="10" fill="var(--color-nextcloud-blue)"/>
@@ -62,8 +61,8 @@
         <label class="office-card{{ isAnyRunning ? ' office-card-disabled' : '' }}" for="office-collabora">
             <div class="office-card-header">
                 <div>
-                    <h4>Nextcloud Office</h4>
-                    <p class="office-powered-by">powered by Collabora Online</p>
+                    <h4>Collabora Online</h4>
+                    <p class="office-powered-by">by Collabora Productivity</p>
                 </div>
                 <svg class="office-checkmark" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <circle cx="12" cy="12" r="10" fill="var(--color-nextcloud-blue)"/>

--- a/php/templates/includes/optional-containers.twig
+++ b/php/templates/includes/optional-containers.twig
@@ -302,7 +302,7 @@
         </form>
         <p>You need to make sure that the options that you enter are valid. An example is <strong>--o:net.content_security_policy=frame-ancestors *.example.com:*;</strong>.</p>
     {% else %}
-        <p>The additioinal options for Collabora Online are currently set to <strong>{{ collabora_additional_options }}</strong>. You can reset them again by clicking on the button below.</p>
+        <p>The additional options for Collabora Online are currently set to <strong>{{ collabora_additional_options }}</strong>. You can reset them again by clicking on the button below.</p>
         <form method="POST" action="api/configuration" class="xhr">
             <input type="hidden" name="delete_collabora_additional_options" value="yes"/>
             <input type="hidden" name="{{csrf.keys.name}}" value="{{csrf.name}}">

--- a/php/templates/includes/optional-containers.twig
+++ b/php/templates/includes/optional-containers.twig
@@ -268,46 +268,46 @@
 {% endif %}
 
 {% if office_suite == 'collabora' and isAnyRunning == false and was_start_button_clicked == true %}
-    <h3>Nextcloud Office dictionaries</h3>
+    <h3>Collabora Online dictionaries</h3>
 
     {% if collabora_dictionaries == "" %}
-        <p>In order to get the correct dictionaries in Nextcloud Office, you may configure the dictionaries below:</p>
+        <p>In order to get the correct dictionaries in Collabora Online, you may configure the dictionaries below:</p>
         <form method="POST" action="api/configuration" class="xhr">
             <input type="text" name="collabora_dictionaries" placeholder="de_DE en_GB en_US es_ES fr_FR it nl pt_BR pt_PT ru" />
             <input type="hidden" name="{{csrf.keys.name}}" value="{{csrf.name}}">
             <input type="hidden" name="{{csrf.keys.value}}" value="{{csrf.value}}">
-            <input type="submit" value="Submit Nextcloud Office dictionaries" />
+            <input type="submit" value="Submit Collabora Online dictionaries" />
         </form>
         <p>You need to make sure that the dictionaries that you enter are valid. An example is <strong>de_DE en_GB en_US es_ES fr_FR it nl pt_BR pt_PT ru</strong>.</p>
     {% else %}
-        <p>The dictionaries for Nextcloud Office are currently set to <strong>{{ collabora_dictionaries }}</strong>. You can reset them again by clicking on the button below.</p>
+        <p>The dictionaries for Collabora Online are currently set to <strong>{{ collabora_dictionaries }}</strong>. You can reset them again by clicking on the button below.</p>
         <form method="POST" action="api/configuration" class="xhr">
             <input type="hidden" name="delete_collabora_dictionaries" value="yes"/>
             <input type="hidden" name="{{csrf.keys.name}}" value="{{csrf.name}}">
             <input type="hidden" name="{{csrf.keys.value}}" value="{{csrf.value}}">
-            <input type="submit" value="Reset Nextcloud Office dictionaries" />
+            <input type="submit" value="Reset Collabora Online dictionaries" />
         </form>
     {% endif %}
 
-    <h3>Additional Nextcloud Office options</h3>
+    <h3>Additional Collabora Online options</h3>
 
     {% if collabora_additional_options == "" %}
-        <p>You can configure additional options for Nextcloud Office below.</p>
+        <p>You can configure additional options for Collabora Online below.</p>
         <p>(This can be used for configuring the net.content_security_policy and more. Make sure to submit the value!)</p>
         <form method="POST" action="api/configuration" class="xhr">
             <input type="text" name="collabora_additional_options" />
             <input type="hidden" name="{{csrf.keys.name}}" value="{{csrf.name}}">
             <input type="hidden" name="{{csrf.keys.value}}" value="{{csrf.value}}">
-            <input type="submit" value="Submit additional Nextcloud Office options" />
+            <input type="submit" value="Submit additional Collabora Online options" />
         </form>
         <p>You need to make sure that the options that you enter are valid. An example is <strong>--o:net.content_security_policy=frame-ancestors *.example.com:*;</strong>.</p>
     {% else %}
-        <p>The additioinal options for Nextcloud Office are currently set to <strong>{{ collabora_additional_options }}</strong>. You can reset them again by clicking on the button below.</p>
+        <p>The additioinal options for Collabora Online are currently set to <strong>{{ collabora_additional_options }}</strong>. You can reset them again by clicking on the button below.</p>
         <form method="POST" action="api/configuration" class="xhr">
             <input type="hidden" name="delete_collabora_additional_options" value="yes"/>
             <input type="hidden" name="{{csrf.keys.name}}" value="{{csrf.name}}">
             <input type="hidden" name="{{csrf.keys.value}}" value="{{csrf.value}}">
-            <input type="submit" value="Reset additional Nextcloud Office options" />
+            <input type="submit" value="Reset additional Collabora Online options" />
         </form>
     {% endif %}
 {% endif %}

--- a/readme.md
+++ b/readme.md
@@ -10,8 +10,8 @@ Included are:
 - High performance backend for Nextcloud Files (Client Push)
 - Redis & APCU for performant caching
 - PostgreSQL as database
+- Collabora Online (optional)
 - Nextcloud Office (optional)
-- EuroOffice (optional)
 - High performance backend for Nextcloud Talk and TURN-server (optional)
 - Nextcloud Talk Recording-server (optional)
 - Backup solution (optional, based on [BorgBackup](https://github.com/borgbackup/borg#what-is-borgbackup))
@@ -118,8 +118,8 @@ flowchart TB
         end
 
         subgraph OPT["  🧩  Optional Built-in Containers  (enable in AIO interface)  "]
-            COLLA(["📄 Nextcloud Office"]):::opt
-            EO(["📄 EuroOffice\nDocument Server"]):::opt
+            COLLA(["📄 Collabora Online"]):::opt
+            EO(["📄 Nextcloud Office\nDocument Server"]):::opt
             TALK(["🎙️ Talk\nVideo & Voice calls"]):::opt
             TALKREC(["🎬 Talk Recording"]):::opt
             FTS(["🔎 Full-text Search\n(Elasticsearch)"]):::opt
@@ -407,7 +407,7 @@ Since Cloudflare Proxy/Tunnel comes with a lot of limitations which are listed b
 - Cloudflare only supports uploading files up to 100 MB in the free plan, if you try to upload bigger files you will get an error (413 - Payload Too Large) if no chunking is used (e.g. for public uploads in the web, or if chunks are configured to be bigger than 100 MB in the clients or the web). If you need to upload bigger files, you need to disable the proxy option in your DNS settings. Note that this will both disable Cloudflare DDoS protection and Cloudflare Tunnel as these services require the proxy option to be enabled.
 - If using Cloudflare Tunnel and the Nextcloud Desktop Client [Set Chunking on Nextcloud Desktop Client](https://github.com/nextcloud/desktop/issues/4271#issuecomment-1159578065)
 - Cloudflare only allows a max timeout of 100s for requests which is not configurable. This means that any server-side processing e.g. for assembling chunks for big files during upload that take longer than 100s will simply not work. See https://github.com/nextcloud/server/issues/19223. If you need to upload big files reliably, you need to disable the proxy option in your DNS settings. Note that this will both disable Cloudflare DDoS protection and Cloudflare Tunnel as these services require the proxy option to be enabled.
-- It is known that the in AIO included collabora (Nextcloud Office) does not work out of the box behind Cloudflare. To make it work, you need to add all [Cloudflare IP-ranges](https://www.cloudflare.com/ips/) to the wopi-allowlist in `https://yourdomain.com/settings/admin/richdocuments`
+- It is known that the in AIO included Collabora Online does not work out of the box behind Cloudflare. To make it work, you need to add all [Cloudflare IP-ranges](https://www.cloudflare.com/ips/) to the wopi-allowlist in `https://yourdomain.com/settings/admin/richdocuments`
 - Cloudflare Proxy might block the Turnserver for Nextcloud Talk from working correctly. You might want to disable Cloudflare Proxy thus. See https://github.com/nextcloud/all-in-one/discussions/2463#discussioncomment-5779981
 - The built-in turn-server for Nextcloud Talk will not work behind Cloudflare Tunnel since it needs a separate port (by default 3478 or as chosen) available on the same domain. If you still want to use the feature, you will need to install your own turnserver or use a publicly available one and adjust and test your stun and turn settings in `https://yourdomain.com/settings/admin/talk`.
 - If you get an error in Nextcloud's admin overview that the HSTS header is not set correctly, you might need to enable it in Cloudflare manually.

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ Included are:
 - Redis & APCU for performant caching
 - PostgreSQL as database
 - Collabora Online (optional)
-- Nextcloud Office (optional)
+- Nextcloud Office (optional, based on Euro-Office)
 - High performance backend for Nextcloud Talk and TURN-server (optional)
 - Nextcloud Talk Recording-server (optional)
 - Backup solution (optional, based on [BorgBackup](https://github.com/borgbackup/borg#what-is-borgbackup))

--- a/tests/QA/002-new-instance.md
+++ b/tests/QA/002-new-instance.md
@@ -23,7 +23,7 @@ For the below to work, it is important that you have a domain that you point ont
 - [ ] Below that you should see a section `Optional addons` which shows a checkbox list with addons that can be enabled or disabled.
     - [ ] Collabora, Imaginary, Talk and Whiteboard should be enabled, the rest disabled
     - [ ] Unchecking/Checking any of these should insert a button that allows to save the set config
-    - [ ] Only one of Collabora, OnlyOffice and EuroOffice should be selectable at the same time
+    - [ ] Only one of Collabora Online, ONLYOFFICE and Nextcloud Office should be selectable at the same time
     - [ ] Recommended is to uncheck all options now
     - [ ] Clicking on the save button should reload the page and activate the new config
 - [ ] Clickig on the `Start containers` button should finally reveal a big spinning wheel that should block all elements on the side of being clicked.


### PR DESCRIPTION
## Summary

Updates the office suite naming in the AIO interface so the two bundled
office suites are no longer both called "Nextcloud Office".

The Collabora container and its chooser card become **Collabora Online**
("by Collabora Productivity", matching the ONLYOFFICE card's "by Ascensio
System SIA"). The Euro-Office container's display name becomes **Nextcloud
Office**. ONLYOFFICE is untouched.

This is the AIO half of a coordinated rename. The other half is
nextcloud/richdocuments#6074.

## Why

AIO ships two office suites and, before this change, labelled both of them
"Nextcloud Office" — the Collabora container in `containers.json` and the
Euro-Office chooser card. That made the suite picker ambiguous at the exact
point where a user has to choose between them.

The two halves are at different stages:

- **Euro-Office** already ships as "Nextcloud Office" — `appinfo/info.xml`
  on `Euro-Office/eurooffice-nextcloud` `main` says so today. AIO's label is
  catching up to the app it installs, not leading it.
- **Collabora** does not yet. `nextcloud/richdocuments` `main` still says
  "Nextcloud Office (Collabora)"; the rename lives in the open PR
  nextcloud/richdocuments#6074.

### Merge ordering

If this merges before nextcloud/richdocuments#6074, the AIO chooser will say
"Collabora Online" while the app it installs still identifies itself as
"Nextcloud Office (Collabora)" inside Nextcloud, until the next richdocuments
release reaches users.

I consider that window acceptable — it is cosmetic, self-correcting, and
strictly less confusing than the current state where both suites share one
name — but it is a deliberate choice rather than an oversight, so flagging it
here. Happy to hold this until richdocuments#6074 lands if maintainers prefer.


## Testing

- [ ] Office suite chooser: all three cards show the correct titles and vendor lines
- [ ] Titles, checkmarks and feature lists line up across all three cards
- [ ] Collabora and ONLYOFFICE cards render unchanged from `main`
- [ ] Chooser at narrow viewport widths, including where the grid collapses to one column
- [ ] Container list shows the new display names
- [ ] Dictionaries / additional options section with Collabora selected
- [ ] Switching between office suites still works and only one stays selectable


Assisted-by: ClaudeCode:opus-5